### PR TITLE
misc/enable calendar api in gcp

### DIFF
--- a/content/docs/api/getting-started/calendars/setup.mdx
+++ b/content/docs/api/getting-started/calendars/setup.mdx
@@ -43,6 +43,10 @@ For **Google Workspace**:
 - `https://www.googleapis.com/auth/calendar.readonly` - To read calendar and event data
 - `https://www.googleapis.com/auth/calendar.events.readonly` - To access event details
 
+<Callout type="warn">
+  **Important**: Ensure the Google Calendar API is enabled for your Google Cloud Platform (GCP) project. You can enable it in the Google Cloud Console under "APIs & Services" > "Library" > "Google Calendar API".
+</Callout>
+
 For **Microsoft Outlook**:
 
 - `Calendars.Read` - To read calendar and event data

--- a/content/docs/api/getting-started/calendars/setup.mdx
+++ b/content/docs/api/getting-started/calendars/setup.mdx
@@ -44,9 +44,9 @@ For **Google Workspace**:
 - `https://www.googleapis.com/auth/calendar.events.readonly` - To access event details
 
 <Callout type="warn">
-  **Important**: Ensure the Google Calendar API is enabled for your Google Cloud Platform (GCP) project. You can enable it in the Google Cloud Console under "APIs & Services" > "Library" > "Google Calendar API".
+  **Important**: Make sure the Google Calendar API is enabled for the Google Cloud project that owns your OAuth client. In Google Cloud Console, switch to the correct project, then go to "APIs & Services" > "Library" > "Google Calendar API" and click "Enable". You can also open the API page directly: [Google Calendar API](https://console.cloud.google.com/apis/library/calendar-json.googleapis.com).
+  If you encounter a "500 Internal Server Error" when creating a calendar integration, verify that this API is enabled and retry.
 </Callout>
-
 For **Microsoft Outlook**:
 
 - `Calendars.Read` - To read calendar and event data


### PR DESCRIPTION
The SDK 5.0.2 will produce a internal server error 500 if the google project doesn't have the google calendar API enabled.
This should be fixed in the SDK error handling as well but I don't have time, feel free to reject this, just thought this note will help someone. Also not familiar with mdx so apologise if this is not how I should contribute.