### PR TITLE
fix: Alerts, webhooks improvements, API reference updates

### DIFF
--- a/content/docs/api-v2/alerts.mdx
+++ b/content/docs/api-v2/alerts.mdx
@@ -1,0 +1,134 @@
+---
+title: Alerts
+description: Configure alerts to monitor bot operations, resource usage, and webhook delivery health
+icon: Bell
+---
+
+Alerts notify you when something goes wrong or when resource thresholds are reached. Configure alert rules from your dashboard to receive email notifications and HTTP callbacks in real-time.
+
+## Overview
+
+The alerts system monitors two categories of events:
+
+- **Operational alerts** detect errors during bot operations — failed joins, recording failures, crashes, and more
+- **Threshold alerts** monitor resource metrics like token balance, daily bot usage, and calendar connections
+
+Each alert rule defines what to monitor, when to trigger, how to notify you, and how often.
+
+## Creating an Alert Rule
+
+Navigate to **Alerts** in your dashboard to create a new rule. Each rule requires:
+
+1. **Alert type** — what to monitor (see [Alert Types](#alert-types) below)
+2. **Threshold** — the value that triggers the alert
+3. **Delivery channels** — where to send notifications (email, callback, or both)
+4. **Cooldown** — minimum time between consecutive alerts (1–1440 minutes, default: 15 minutes)
+
+At least one delivery channel (email or callback) is required.
+
+## Alert Types
+
+### Operational Alerts
+
+Operational alerts fire when errors accumulate within the cooldown window. For example, "alert me when bot crashes reach 3 occurrences within 15 minutes."
+
+| Alert Type | Description | Common Triggers |
+|------------|-------------|-----------------|
+| Bot Join Failed | Bot could not join the meeting | Invalid meeting URL, meeting ended before bot joined, login required, waiting for host timeout, bot not accepted |
+| Recording Failed | Bot joined but could not record | Recording rights not granted, recording start timeout, host cannot grant permission |
+| Zoom Credential Error | Zoom authentication failure | Invalid JWT token, SDK auth failed, access token error |
+| Bot Crash | Bot process exited unexpectedly | Out of memory, force killed, general error |
+| Transcription Failed | Transcription service error | Provider returned an error after recording completed |
+| Calendar Sync Error | Calendar synchronization failure | OAuth token expired, provider API error |
+| Webhook Delivery Exhausted | All webhook retry attempts failed | Endpoint unreachable, returning errors consistently |
+
+<Callout type="info">
+The **Webhook Delivery Exhausted** alert is particularly important — it fires each time a webhook message exhausts all retry attempts. If your webhook endpoint is down, you'll receive one alert per failed message, giving you immediate visibility before the endpoint is automatically disabled. See [Webhook Auto-Disable](/docs/api-v2/webhooks#auto-disable) for details.
+</Callout>
+
+### Threshold Alerts
+
+Threshold alerts fire when a resource metric crosses a configured boundary. They support both `>=` (greater than or equal) and `<=` (less than or equal) operators.
+
+| Alert Type | Description | Example Use Case |
+|------------|-------------|------------------|
+| Daily Bot Cap | Number of bots created today | "Alert me when daily bots reach 90% of my plan limit" |
+| Token Balance | Current token balance | "Alert me when tokens drop below 1000" |
+| Calendar Connections | Number of connected calendars | "Alert me when calendar connections reach my plan limit" |
+
+## Delivery Channels
+
+Each alert rule can use one or both delivery channels:
+
+### Email
+
+Configure up to 10 email recipients per rule. When an alert fires, all recipients receive an email containing:
+
+- Alert rule name
+- Current metric value and threshold
+- Number of suppressed alerts during the cooldown period (if any)
+- Direct link to the dashboard
+
+### Callback
+
+Configure an HTTP endpoint to receive alert notifications programmatically. Callbacks are sent as `POST` requests with a JSON payload:
+
+```json
+{
+  "alert_rule_id": "550e8400-e29b-41d4-a716-446655440000",
+  "alert_rule_name": "Bot Crash Monitor",
+  "alert_type": "bot_crash",
+  "category": "operational",
+  "triggered_at": "2025-01-15T10:30:00.000Z",
+  "current_value": 3,
+  "threshold_value": 3,
+  "suppressed_count": 0,
+  "message": "Bot Crash: 3 occurrence(s) reached threshold of 3"
+}
+```
+
+If you configure a `secret` on the callback, it is included as the `x-mb-alert-secret` header for verification.
+
+**Callback retry behavior:**
+- 4 total attempts (initial + 3 retries)
+- Retry delays: 1 second, 5 seconds, 15 seconds
+- Only retries on network errors and 5xx server responses
+- Does **not** retry on 4xx client errors
+- 30-second request timeout
+
+## Cooldown and Suppression
+
+The cooldown period (default: 15 minutes) prevents alert fatigue by batching rapid-fire events:
+
+1. When an alert fires, a cooldown window starts
+2. During cooldown, additional triggers are **counted but not delivered**
+3. When the cooldown expires and the next trigger occurs, the alert fires again with a **suppressed count** showing how many events were batched
+
+**Example:** You configure a "Bot Join Failed" alert with threshold `>= 1` and a 15-minute cooldown.
+
+- `10:00` — First bot join fails → alert fires immediately
+- `10:02` — Second failure → suppressed (cooldown active)
+- `10:08` — Third failure → suppressed (cooldown active)
+- `10:16` — Fourth failure → alert fires with `suppressed_count: 2` (the two suppressed events from 10:02 and 10:08)
+
+## Testing Alerts
+
+Use the **Test** button on any alert rule to send a test notification to all configured delivery channels. This verifies that your email addresses are correct and your callback endpoint is reachable.
+
+## Alert History
+
+Each alert rule maintains a delivery history accessible from the rule's detail page. History entries include:
+
+- When the alert fired
+- Current value at the time of trigger
+- Number of suppressed events
+- Delivery status for each channel (success or failure with error details)
+
+## Limits
+
+| Setting | Limit |
+|---------|-------|
+| Alert rules per team | 50 |
+| Email recipients per rule | 10 |
+| Cooldown range | 1–1440 minutes (24 hours) |
+| Minimum threshold for operational alerts | 1 occurrence |

--- a/content/docs/api-v2/alerts.mdx
+++ b/content/docs/api-v2/alerts.mdx
@@ -30,7 +30,7 @@ At least one delivery channel (email or callback) is required.
 
 ### Operational Alerts
 
-Operational alerts fire when errors accumulate within the cooldown window. For example, "alert me when bot crashes reach 3 occurrences within 15 minutes."
+Operational alerts count error occurrences and fire when the count reaches your configured threshold. The same cooldown window is used for both counting events and suppressing repeated alerts after delivery (see [Cooldown and Suppression](#cooldown-and-suppression) below). For example, "alert me when bot crashes reach 3 occurrences within 15 minutes."
 
 | Alert Type | Description | Common Triggers |
 |------------|-------------|-----------------|
@@ -43,7 +43,7 @@ Operational alerts fire when errors accumulate within the cooldown window. For e
 | Webhook Delivery Exhausted | All webhook retry attempts failed | Endpoint unreachable, returning errors consistently |
 
 <Callout type="info">
-The **Webhook Delivery Exhausted** alert is particularly important — it fires each time a webhook message exhausts all retry attempts. If your webhook endpoint is down, you'll receive one alert per failed message, giving you immediate visibility before the endpoint is automatically disabled. See [Webhook Auto-Disable](/docs/api-v2/webhooks#auto-disable) for details.
+The **Webhook Delivery Exhausted** alert is particularly important — each time a webhook message exhausts all retry attempts, the alert metric increments. If cooldown is active, additional exhausted deliveries are aggregated into the `suppressed_count` and reported when the next alert fires. This gives you visibility into endpoint health well before the 5-day auto-disable threshold. See [Webhook Auto-Disable](/docs/api-v2/webhooks#auto-disable) for details.
 </Callout>
 
 ### Threshold Alerts
@@ -98,18 +98,25 @@ If you configure a `secret` on the callback, it is included as the `x-mb-alert-s
 
 ## Cooldown and Suppression
 
-The cooldown period (default: 15 minutes) prevents alert fatigue by batching rapid-fire events:
+The cooldown period (default: 15 minutes) serves a dual purpose — it is both the **counting window** for accumulating events toward a threshold and the **suppression window** that prevents repeated alerts after delivery.
 
-1. When an alert fires, a cooldown window starts
-2. During cooldown, additional triggers are **counted but not delivered**
-3. When the cooldown expires and the next trigger occurs, the alert fires again with a **suppressed count** showing how many events were batched
+**How it works:**
+
+1. Events are counted within a rolling window equal to the cooldown period
+2. When the count reaches the threshold, the alert fires and delivery begins
+3. After delivery, the cooldown starts — additional events during this period are **counted but not delivered**
+4. When the cooldown expires and the next trigger occurs, the alert fires again with a `suppressed_count` showing how many events were batched during the suppression period
+
+<Callout type="info">
+The system intentionally uses the same time window for both event accumulation (pre-trigger) and post-delivery suppression. For example, with a threshold of `>= 3` and a 15-minute cooldown, the system counts occurrences within a 15-minute window. Once 3 events are reached and the alert fires, the same 15-minute period becomes the suppression window.
+</Callout>
 
 **Example:** You configure a "Bot Join Failed" alert with threshold `>= 1` and a 15-minute cooldown.
 
-- `10:00` — First bot join fails → alert fires immediately
+- `10:00` — First bot join fails → threshold met, alert fires immediately
 - `10:02` — Second failure → suppressed (cooldown active)
 - `10:08` — Third failure → suppressed (cooldown active)
-- `10:16` — Fourth failure → alert fires with `suppressed_count: 2` (the two suppressed events from 10:02 and 10:08)
+- `10:16` — Fourth failure → cooldown expired, alert fires with `suppressed_count: 2`
 
 ## Testing Alerts
 

--- a/content/docs/api-v2/meta.json
+++ b/content/docs/api-v2/meta.json
@@ -10,6 +10,7 @@
     "migration-guide",
     "api-keys",
     "webhooks",
+    "alerts",
     "transcription",
     "streaming",
     "artifacts",

--- a/content/docs/api-v2/webhooks.mdx
+++ b/content/docs/api-v2/webhooks.mdx
@@ -430,6 +430,7 @@ A small amount of random jitter (±20%) is added to each retry delay to prevent 
 
 ### Timeouts and Overload Protection
 
+- **Successful acknowledgement**: Only HTTP `2xx` responses are treated as successful delivery. Any other status code — including `3xx` redirects, `4xx` client errors, and `5xx` server errors — is considered a failure and will be retried. Failed deliveries contribute to the retry schedule and, over time, to the [auto-disable](#auto-disable) behavior.
 - **Request timeout**: Your endpoint must respond within 30 seconds. Requests that exceed this limit are treated as failures and retried.
 - **Overload penalty**: If your endpoint returns a `429 Too Many Requests` status or times out, a minimum 60-second delay is applied before the next retry, regardless of the scheduled delay.
 

--- a/content/docs/api-v2/webhooks.mdx
+++ b/content/docs/api-v2/webhooks.mdx
@@ -410,10 +410,49 @@ Triggered when an event is cancelled in a connected calendar.
 
 ## Webhook Delivery
 
-- **Retries**: SVIX automatically retries failed webhook deliveries
-- **Timeout**: Webhook endpoints should respond within 30 seconds
-- **Idempotency**: Webhooks may be delivered multiple times - ensure your handler is idempotent
-- **Ordering**: Webhooks are delivered in order, but network issues may cause out-of-order delivery
+### Retry Schedule
+
+Failed webhook deliveries are automatically retried with increasing delays:
+
+| Attempt | Delay | Cumulative Time |
+|---------|-------|-----------------|
+| 1 (initial) | — | 0s |
+| 2 | 5 seconds | ~5s |
+| 3 | 10 seconds | ~15s |
+| 4 | 5 minutes | ~5 min |
+| 5 | 15 minutes | ~20 min |
+| 6 | 30 minutes | ~50 min |
+| 7 | 2 hours | ~3 hours |
+
+All retries complete within approximately 3 hours. This is intentional — `bot.completed` webhooks include signed download URLs (for video, audio, transcription) that are **valid for 4 hours**. Keeping retries within this window ensures that URLs in the payload remain usable.
+
+A small amount of random jitter (±20%) is added to each retry delay to prevent thundering herd issues.
+
+### Timeouts and Overload Protection
+
+- **Request timeout**: Your endpoint must respond within 30 seconds. Requests that exceed this limit are treated as failures and retried.
+- **Overload penalty**: If your endpoint returns a `429 Too Many Requests` status or times out, a minimum 60-second delay is applied before the next retry, regardless of the scheduled delay.
+
+### Idempotency and Ordering
+
+- **Idempotency**: Webhooks may be delivered multiple times — ensure your handler is idempotent
+- **Ordering**: Webhooks are generally delivered in order, but network issues or retries may cause out-of-order delivery
+
+### Endpoint Auto-Disable <span id="auto-disable" />
+
+If your webhook endpoint fails continuously for an extended period, it will be automatically disabled to prevent unnecessary retry traffic:
+
+1. **After all retry attempts fail** for a message, a `webhook_delivery_exhausted` operational alert is emitted (if you have [alert rules](/docs/api-v2/alerts) configured for this type)
+2. **After 5 days of continuous failure** (no successful delivery across any message), the endpoint is automatically disabled
+3. **When auto-disabled**, the team owner receives an email notification with the endpoint details and common failure causes
+4. **Your endpoint status** is updated in the dashboard — you'll see it marked as disabled
+5. **No new deliveries** are attempted to a disabled endpoint until you manually re-enable it from the dashboard
+
+<Callout type="warn">
+Once an endpoint is auto-disabled, all subsequent webhook messages are silently dropped. Configure a **Webhook Delivery Exhausted** alert rule to get notified per-message as retries fail, well before the 5-day auto-disable threshold. See [Alerts](/docs/api-v2/alerts) for setup instructions.
+</Callout>
+
+A single successful delivery at any point resets the failure clock — the 5-day timer only applies to endpoints that fail every delivery attempt without any success.
 
 ## Testing Webhooks
 
@@ -453,9 +492,22 @@ When creating a bot, include the `callback_config` in your request:
 
 If you provide a `secret` in `callback_config`, it will be included in the `x-mb-secret` header of all callback requests. Use this to verify that callbacks are coming from Meeting BaaS.
 
-### Retrying Callbacks
+### Callback Delivery and Retries
 
-If a callback delivery fails, you can retry it using the `POST /v2/bots/:bot_id/retry-callback` endpoint.
+Callbacks are delivered with automatic retries on failure:
+
+| Attempt | Delay |
+|---------|-------|
+| 1 (initial) | — |
+| 2 | 1 second |
+| 3 | 5 seconds |
+| 4 | 15 seconds |
+
+- Only retries on **network errors** and **5xx server responses**
+- Does **not** retry on **4xx client errors** (e.g., 400, 401, 403, 404)
+- 30-second request timeout per attempt
+
+If all 4 attempts fail, you can manually retry using the `POST /v2/bots/:bot_id/retry-callback` endpoint. This generates a fresh payload with new signed download URLs.
 
 ## Resending Webhooks
 

--- a/content/docs/api/reference/webhooks/bot_webhook_documentation.mdx
+++ b/content/docs/api/reference/webhooks/bot_webhook_documentation.mdx
@@ -50,8 +50,8 @@ _openapi:
                 }
               ],
               \"speakers\": [
-                \"Jane Smith\",
-                \"John Doe\"
+                \"John Doe\",
+                \"Jane Smith\"
               ],
               \"mp4\": \"https://storage.example.com/recordings/video123.mp4?token=abc\",
               \"audio\": \"https://storage.example.com/recordings/audio123.wav?token=abc\",
@@ -236,8 +236,8 @@ Sent when a bot successfully completes recording a meeting.
       }
     ],
     \"speakers\": [
-      \"Jane Smith\",
-      \"John Doe\"
+      \"John Doe\",
+      \"Jane Smith\"
     ],
     \"mp4\": \"https://storage.example.com/recordings/video123.mp4?token=abc\",
     \"audio\": \"https://storage.example.com/recordings/audio123.wav?token=abc\",

--- a/content/docs/api/reference/webhooks/webhook_documentation.mdx
+++ b/content/docs/api/reference/webhooks/webhook_documentation.mdx
@@ -48,8 +48,8 @@ _openapi:
                 }
               ],
               \"speakers\": [
-                \"John Doe\",
-                \"Jane Smith\"
+                \"Jane Smith\",
+                \"John Doe\"
               ],
               \"mp4\": \"https://storage.example.com/recordings/video123.mp4?token=abc\",
               \"audio\": \"https://storage.example.com/recordings/audio123.wav?token=abc\",
@@ -291,8 +291,8 @@ Sent when a bot successfully completes recording a meeting. Contains full transc
       }
     ],
     \"speakers\": [
-      \"John Doe\",
-      \"Jane Smith\"
+      \"Jane Smith\",
+      \"John Doe\"
     ],
     \"mp4\": \"https://storage.example.com/recordings/video123.mp4?token=abc\",
     \"audio\": \"https://storage.example.com/recordings/audio123.wav?token=abc\",

--- a/content/llm/api-all.md
+++ b/content/llm/api-all.md
@@ -297,8 +297,8 @@ Sent when a bot successfully completes recording a meeting.
       }
     ],
     \"speakers\": [
-      \"Jane Smith\",
-      \"John Doe\"
+      \"John Doe\",
+      \"Jane Smith\"
     ],
     \"mp4\": \"https://storage.example.com/recordings/video123.mp4?token=abc\",
     \"audio\": \"https://storage.example.com/recordings/audio123.wav?token=abc\",
@@ -500,8 +500,8 @@ Sent when a bot successfully completes recording a meeting. Contains full transc
       }
     ],
     \"speakers\": [
-      \"John Doe\",
-      \"Jane Smith\"
+      \"Jane Smith\",
+      \"John Doe\"
     ],
     \"mp4\": \"https://storage.example.com/recordings/video123.mp4?token=abc\",
     \"audio\": \"https://storage.example.com/recordings/audio123.wav?token=abc\",

--- a/content/llm/api-v2.md
+++ b/content/llm/api-v2.md
@@ -2,6 +2,145 @@
 
 Documentation for api-v2.
 
+## Alerts
+
+Configure alerts to monitor bot operations, resource usage, and webhook delivery health
+
+### Source: ./content/docs/api-v2/alerts.mdx
+
+
+Alerts notify you when something goes wrong or when resource thresholds are reached. Configure alert rules from your dashboard to receive email notifications and HTTP callbacks in real-time.
+
+## Overview
+
+The alerts system monitors two categories of events:
+
+- **Operational alerts** detect errors during bot operations — failed joins, recording failures, crashes, and more
+- **Threshold alerts** monitor resource metrics like token balance, daily bot usage, and calendar connections
+
+Each alert rule defines what to monitor, when to trigger, how to notify you, and how often.
+
+## Creating an Alert Rule
+
+Navigate to **Alerts** in your dashboard to create a new rule. Each rule requires:
+
+1. **Alert type** — what to monitor (see [Alert Types](#alert-types) below)
+2. **Threshold** — the value that triggers the alert
+3. **Delivery channels** — where to send notifications (email, callback, or both)
+4. **Cooldown** — minimum time between consecutive alerts (1–1440 minutes, default: 15 minutes)
+
+At least one delivery channel (email or callback) is required.
+
+## Alert Types
+
+### Operational Alerts
+
+Operational alerts fire when errors accumulate within the cooldown window. For example, "alert me when bot crashes reach 3 occurrences within 15 minutes."
+
+| Alert Type | Description | Common Triggers |
+|------------|-------------|-----------------|
+| Bot Join Failed | Bot could not join the meeting | Invalid meeting URL, meeting ended before bot joined, login required, waiting for host timeout, bot not accepted |
+| Recording Failed | Bot joined but could not record | Recording rights not granted, recording start timeout, host cannot grant permission |
+| Zoom Credential Error | Zoom authentication failure | Invalid JWT token, SDK auth failed, access token error |
+| Bot Crash | Bot process exited unexpectedly | Out of memory, force killed, general error |
+| Transcription Failed | Transcription service error | Provider returned an error after recording completed |
+| Calendar Sync Error | Calendar synchronization failure | OAuth token expired, provider API error |
+| Webhook Delivery Exhausted | All webhook retry attempts failed | Endpoint unreachable, returning errors consistently |
+
+<Callout type="info">
+The **Webhook Delivery Exhausted** alert is particularly important — it fires each time a webhook message exhausts all retry attempts. If your webhook endpoint is down, you'll receive one alert per failed message, giving you immediate visibility before the endpoint is automatically disabled. See [Webhook Auto-Disable](/docs/api-v2/webhooks#auto-disable) for details.
+</Callout>
+
+### Threshold Alerts
+
+Threshold alerts fire when a resource metric crosses a configured boundary. They support both `>=` (greater than or equal) and `<=` (less than or equal) operators.
+
+| Alert Type | Description | Example Use Case |
+|------------|-------------|------------------|
+| Daily Bot Cap | Number of bots created today | "Alert me when daily bots reach 90% of my plan limit" |
+| Token Balance | Current token balance | "Alert me when tokens drop below 1000" |
+| Calendar Connections | Number of connected calendars | "Alert me when calendar connections reach my plan limit" |
+
+## Delivery Channels
+
+Each alert rule can use one or both delivery channels:
+
+### Email
+
+Configure up to 10 email recipients per rule. When an alert fires, all recipients receive an email containing:
+
+- Alert rule name
+- Current metric value and threshold
+- Number of suppressed alerts during the cooldown period (if any)
+- Direct link to the dashboard
+
+### Callback
+
+Configure an HTTP endpoint to receive alert notifications programmatically. Callbacks are sent as `POST` requests with a JSON payload:
+
+```json
+{
+  "alert_rule_id": "550e8400-e29b-41d4-a716-446655440000",
+  "alert_rule_name": "Bot Crash Monitor",
+  "alert_type": "bot_crash",
+  "category": "operational",
+  "triggered_at": "2025-01-15T10:30:00.000Z",
+  "current_value": 3,
+  "threshold_value": 3,
+  "suppressed_count": 0,
+  "message": "Bot Crash: 3 occurrence(s) reached threshold of 3"
+}
+```
+
+If you configure a `secret` on the callback, it is included as the `x-mb-alert-secret` header for verification.
+
+**Callback retry behavior:**
+- 4 total attempts (initial + 3 retries)
+- Retry delays: 1 second, 5 seconds, 15 seconds
+- Only retries on network errors and 5xx server responses
+- Does **not** retry on 4xx client errors
+- 30-second request timeout
+
+## Cooldown and Suppression
+
+The cooldown period (default: 15 minutes) prevents alert fatigue by batching rapid-fire events:
+
+1. When an alert fires, a cooldown window starts
+2. During cooldown, additional triggers are **counted but not delivered**
+3. When the cooldown expires and the next trigger occurs, the alert fires again with a **suppressed count** showing how many events were batched
+
+**Example:** You configure a "Bot Join Failed" alert with threshold `>= 1` and a 15-minute cooldown.
+
+- `10:00` — First bot join fails → alert fires immediately
+- `10:02` — Second failure → suppressed (cooldown active)
+- `10:08` — Third failure → suppressed (cooldown active)
+- `10:16` — Fourth failure → alert fires with `suppressed_count: 2` (the two suppressed events from 10:02 and 10:08)
+
+## Testing Alerts
+
+Use the **Test** button on any alert rule to send a test notification to all configured delivery channels. This verifies that your email addresses are correct and your callback endpoint is reachable.
+
+## Alert History
+
+Each alert rule maintains a delivery history accessible from the rule's detail page. History entries include:
+
+- When the alert fired
+- Current value at the time of trigger
+- Number of suppressed events
+- Delivery status for each channel (success or failure with error details)
+
+## Limits
+
+| Setting | Limit |
+|---------|-------|
+| Alert rules per team | 50 |
+| Email recipients per rule | 10 |
+| Cooldown range | 1–1440 minutes (24 hours) |
+| Minimum threshold for operational alerts | 1 occurrence |
+
+
+---
+
 ## API Keys & Permissions
 
 Learn about API keys, permissions, and access control in Meeting BaaS v2
@@ -1580,6 +1719,22 @@ curl -X POST "https://api.meetingbaas.com/v2/calendars/CALENDAR-ID/bots" \
 - `all_occurrences`: Set to `true` to schedule for all occurrences of a recurring event
 - `series_id`: Use this instead of `event_id` to schedule for an entire series
 
+## Shared Service Account Use Case (Invite-To-Schedule)
+
+Once the OAuth flow is configured, and if you want to avoid creating calendar connections for every end-user, you can connect a single dedicated "bot mailbox" (for example, `recording@xyz.io`) and reuse it.
+
+<Callout type="info">
+  Meeting BaaS v2 uses a bring-your-own-credentials model and requires OAuth refresh tokens obtained via a normal OAuth consent flow. See [Implement OAuth Flow](#implement-oauth-flow) above. The practical workaround for a "service account" is to use a dedicated mailbox/user account that can complete OAuth once, then reuse its refresh token.
+</Callout>
+
+### How it works
+
+1. Create a dedicated provider account and calendar (the bot mailbox).
+2. Run a single OAuth consent flow for the bot mailbox to obtain its refresh token, then connect that calendar to Meeting BaaS v2 using `POST /v2/calendars` (you'll get one `calendar_id` for this shared connection).
+3. When you need a bot, create the meeting/event and invite the bot mailbox. Make sure the event contains a meeting URL (since bot scheduling depends on it).
+4. Meeting BaaS syncs the event into that connection and emits webhooks for the connection and subsequent event changes.
+5. In your webhook handler, schedule the bot for the relevant `event_id` using `POST /v2/calendars/{calendar_id}/bots`. For recurring meetings, prefer `series_id` or `all_occurrences`.
+
 ## Webhooks
 
 Calendar integrations trigger webhook events for:
@@ -1607,7 +1762,12 @@ See the [Webhooks documentation](/docs/api-v2/webhooks) for details on all calen
 
 ## Frequently Asked Questions
 
-### What happens if a calendar event is updated close to its start time?
+<Accordions type="single">
+
+<Accordion
+  id="faq-updated-close-to-start"
+  title="What happens if a calendar event is updated close to its start time?"
+>
 
 **Lock Window Behavior (4 minutes before event start):**
 
@@ -1621,7 +1781,12 @@ When an event is updated within 4 minutes of its start time, the system enters a
 
 If an event is updated more than 4 minutes before its start time, the bot schedule is safely updated with the new event details, and only one bot will join.
 
-### What happens if a calendar event is deleted close to its start time?
+</Accordion>
+
+<Accordion
+  id="faq-deleted-close-to-start"
+  title="What happens if a calendar event is deleted close to its start time?"
+>
 
 **Within Lock Window (4 minutes before start):**
 - The bot schedule remains active and the bot will still attempt to join
@@ -1631,7 +1796,12 @@ If an event is updated more than 4 minutes before its start time, the bot schedu
 - The bot schedule is automatically deleted
 - No bot will be created for the cancelled event
 
-### What happens if the meeting URL is removed from an event?
+</Accordion>
+
+<Accordion
+  id="faq-meeting-url-removed"
+  title="What happens if the meeting URL is removed from an event?"
+>
 
 **If the event originally had a meeting URL:**
 - The bot will use the meeting URL from the bot configuration, which was captured when the bot was scheduled
@@ -1641,21 +1811,30 @@ If an event is updated more than 4 minutes before its start time, the bot schedu
 - No bot schedule is created
 - Calendar events without meeting URLs are skipped during bot scheduling
 
-### How often are calendar events synced?
+</Accordion>
+
+<Accordion id="faq-sync-frequency" title="How often are calendar events synced?">
 
 Calendar events are synced via **push notifications (real-time)**:
 - **Google Calendar**: Push notifications via watch channels (renewed every 7 days)
 - **Microsoft Calendar**: Push notifications via subscriptions (renewed every 2 days)
 - Changes are typically reflected within seconds
 
-### What is the event materialization window?
+</Accordion>
+
+<Accordion
+  id="faq-materialization-window"
+  title="What is the event materialization window?"
+>
 
 Meeting BaaS maintains a **30-day rolling window** of calendar events:
 - Events are synced from **now** to **30 days in the future**
 - Events outside this window are not stored or monitored
 - As time progresses, new events enter the window and old events are removed
 
-### How are recurring events handled?
+</Accordion>
+
+<Accordion id="faq-recurring-events" title="How are recurring events handled?">
 
 **Series-Level Bot Scheduling:**
 - You can schedule a bot for all occurrences of a recurring event using `all_occurrences: true` or by providing the `series_id`
@@ -1672,21 +1851,30 @@ In some cases, the calendar platform may invalidate an event series (such as whe
 
 This behavior is inline with how calendar platforms handle major changes to recurring events.
 
-### What happens if I decline a calendar event?
+</Accordion>
+
+<Accordion id="faq-decline-event" title="What happens if I decline a calendar event?">
 
 If you decline a calendar event (as the calendar owner):
 - The event is treated as **cancelled** in Meeting BaaS
 - No bot will be scheduled for declined events
 - Existing bot schedules for declined events are automatically cancelled
 
-### Can I schedule bots for all-day events?
+</Accordion>
+
+<Accordion id="faq-all-day-events" title="Can I schedule bots for all-day events?">
 
 All-day events are synced and stored, but:
 - They typically don't have meeting URLs
 - Bots are only scheduled for events with valid meeting URLs
 - All-day events without meeting URLs are skipped during bot scheduling
 
-### What meeting platforms are supported?
+</Accordion>
+
+<Accordion
+  id="faq-meeting-platforms"
+  title="What meeting platforms are supported?"
+>
 
 Meeting BaaS automatically detects meeting URLs for:
 - **Zoom** (`zoom.us`)
@@ -1699,7 +1887,12 @@ The meeting platform is detected from:
 - The event description (for embedded links)
 - Conference data (Google Calendar)
 
-### How are event exceptions handled?
+</Accordion>
+
+<Accordion
+  id="faq-event-exceptions"
+  title="How are event exceptions handled?"
+>
 
 **Event exceptions** are recurring event instances that have been modified:
 - Modified start time
@@ -1711,7 +1904,9 @@ Exceptions are:
 - Synced and stored separately from the series pattern
 - Handled correctly for bot scheduling
 
-### What if my OAuth credentials expire?
+</Accordion>
+
+<Accordion id="faq-oauth-expire" title="What if my OAuth credentials expire?">
 
 **Refresh Token Expiration:**
 - Google: Refresh tokens don't expire unless revoked by the user
@@ -1722,7 +1917,12 @@ Exceptions are:
 - You'll receive a webhook notification
 - Users must re-authorize your application to restore the connection
 
-### How do I handle calendar connection errors?
+</Accordion>
+
+<Accordion
+  id="faq-connection-errors"
+  title="How do I handle calendar connection errors?"
+>
 
 Monitor the `status` field on calendar connections:
 - `active`: Connection is working normally
@@ -1732,7 +1932,12 @@ Monitor the `status` field on calendar connections:
 
 You'll receive webhook notifications for connection status changes.
 
-### Can I connect multiple calendars from the same account?
+</Accordion>
+
+<Accordion
+  id="faq-multiple-calendars"
+  title="Can I connect multiple calendars from the same account?"
+>
 
 Yes! You can create separate calendar connections for:
 - Multiple calendars from the same Google account
@@ -1743,6 +1948,9 @@ Each connection is independent and has its own:
 - Sync status
 - Bot schedules
 - Webhook events
+
+</Accordion>
+</Accordions>
 
 
 
@@ -8742,10 +8950,49 @@ Triggered when an event is cancelled in a connected calendar.
 
 ## Webhook Delivery
 
-- **Retries**: SVIX automatically retries failed webhook deliveries
-- **Timeout**: Webhook endpoints should respond within 30 seconds
-- **Idempotency**: Webhooks may be delivered multiple times - ensure your handler is idempotent
-- **Ordering**: Webhooks are delivered in order, but network issues may cause out-of-order delivery
+### Retry Schedule
+
+Failed webhook deliveries are automatically retried with increasing delays:
+
+| Attempt | Delay | Cumulative Time |
+|---------|-------|-----------------|
+| 1 (initial) | — | 0s |
+| 2 | 5 seconds | ~5s |
+| 3 | 10 seconds | ~15s |
+| 4 | 5 minutes | ~5 min |
+| 5 | 15 minutes | ~20 min |
+| 6 | 30 minutes | ~50 min |
+| 7 | 2 hours | ~3 hours |
+
+All retries complete within approximately 3 hours. This is intentional — `bot.completed` webhooks include signed download URLs (for video, audio, transcription) that are **valid for 4 hours**. Keeping retries within this window ensures that URLs in the payload remain usable.
+
+A small amount of random jitter (±20%) is added to each retry delay to prevent thundering herd issues.
+
+### Timeouts and Overload Protection
+
+- **Request timeout**: Your endpoint must respond within 30 seconds. Requests that exceed this limit are treated as failures and retried.
+- **Overload penalty**: If your endpoint returns a `429 Too Many Requests` status or times out, a minimum 60-second delay is applied before the next retry, regardless of the scheduled delay.
+
+### Idempotency and Ordering
+
+- **Idempotency**: Webhooks may be delivered multiple times — ensure your handler is idempotent
+- **Ordering**: Webhooks are generally delivered in order, but network issues or retries may cause out-of-order delivery
+
+### Endpoint Auto-Disable <span id="auto-disable" />
+
+If your webhook endpoint fails continuously for an extended period, it will be automatically disabled to prevent unnecessary retry traffic:
+
+1. **After all retry attempts fail** for a message, a `webhook_delivery_exhausted` operational alert is emitted (if you have [alert rules](/docs/api-v2/alerts) configured for this type)
+2. **After 5 days of continuous failure** (no successful delivery across any message), the endpoint is automatically disabled
+3. **When auto-disabled**, the team owner receives an email notification with the endpoint details and common failure causes
+4. **Your endpoint status** is updated in the dashboard — you'll see it marked as disabled
+5. **No new deliveries** are attempted to a disabled endpoint until you manually re-enable it from the dashboard
+
+<Callout type="warn">
+Once an endpoint is auto-disabled, all subsequent webhook messages are silently dropped. Configure a **Webhook Delivery Exhausted** alert rule to get notified per-message as retries fail, well before the 5-day auto-disable threshold. See [Alerts](/docs/api-v2/alerts) for setup instructions.
+</Callout>
+
+A single successful delivery at any point resets the failure clock — the 5-day timer only applies to endpoints that fail every delivery attempt without any success.
 
 ## Testing Webhooks
 
@@ -8785,9 +9032,22 @@ When creating a bot, include the `callback_config` in your request:
 
 If you provide a `secret` in `callback_config`, it will be included in the `x-mb-secret` header of all callback requests. Use this to verify that callbacks are coming from Meeting BaaS.
 
-### Retrying Callbacks
+### Callback Delivery and Retries
 
-If a callback delivery fails, you can retry it using the `POST /v2/bots/:bot_id/retry-callback` endpoint.
+Callbacks are delivered with automatic retries on failure:
+
+| Attempt | Delay |
+|---------|-------|
+| 1 (initial) | — |
+| 2 | 1 second |
+| 3 | 5 seconds |
+| 4 | 15 seconds |
+
+- Only retries on **network errors** and **5xx server responses**
+- Does **not** retry on **4xx client errors** (e.g., 400, 401, 403, 404)
+- 30-second request timeout per attempt
+
+If all 4 attempts fail, you can manually retry using the `POST /v2/bots/:bot_id/retry-callback` endpoint. This generates a fresh payload with new signed download URLs.
 
 ## Resending Webhooks
 

--- a/content/llm/api-webhooks.md
+++ b/content/llm/api-webhooks.md
@@ -44,8 +44,8 @@ Sent when a bot successfully completes recording a meeting.
       }
     ],
     \"speakers\": [
-      \"Jane Smith\",
-      \"John Doe\"
+      \"John Doe\",
+      \"Jane Smith\"
     ],
     \"mp4\": \"https://storage.example.com/recordings/video123.mp4?token=abc\",
     \"audio\": \"https://storage.example.com/recordings/audio123.wav?token=abc\",
@@ -247,8 +247,8 @@ Sent when a bot successfully completes recording a meeting. Contains full transc
       }
     ],
     \"speakers\": [
-      \"John Doe\",
-      \"Jane Smith\"
+      \"Jane Smith\",
+      \"John Doe\"
     ],
     \"mp4\": \"https://storage.example.com/recordings/video123.mp4?token=abc\",
     \"audio\": \"https://storage.example.com/recordings/audio123.wav?token=abc\",

--- a/content/llm/api.md
+++ b/content/llm/api.md
@@ -3354,8 +3354,8 @@ Sent when a bot successfully completes recording a meeting.
       }
     ],
     \"speakers\": [
-      \"Jane Smith\",
-      \"John Doe\"
+      \"John Doe\",
+      \"Jane Smith\"
     ],
     \"mp4\": \"https://storage.example.com/recordings/video123.mp4?token=abc\",
     \"audio\": \"https://storage.example.com/recordings/audio123.wav?token=abc\",
@@ -3557,8 +3557,8 @@ Sent when a bot successfully completes recording a meeting. Contains full transc
       }
     ],
     \"speakers\": [
-      \"John Doe\",
-      \"Jane Smith\"
+      \"Jane Smith\",
+      \"John Doe\"
     ],
     \"mp4\": \"https://storage.example.com/recordings/video123.mp4?token=abc\",
     \"audio\": \"https://storage.example.com/recordings/audio123.wav?token=abc\",

--- a/openapi-v2.json
+++ b/openapi-v2.json
@@ -864,6 +864,51 @@
                       "type": "null"
                     }
                   ]
+                },
+                "tokens": {
+                  "description": "Token consumption breakdown (null if not yet consumed)",
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "recording": {
+                          "description": "Recording tokens consumed",
+                          "type": "number"
+                        },
+                        "transcription": {
+                          "description": "Transcription tokens consumed",
+                          "type": "number"
+                        },
+                        "byok_transcription": {
+                          "description": "BYOK transcription tokens consumed",
+                          "type": "number"
+                        },
+                        "streaming_input": {
+                          "description": "Streaming input tokens consumed",
+                          "type": "number"
+                        },
+                        "streaming_output": {
+                          "description": "Streaming output tokens consumed",
+                          "type": "number"
+                        },
+                        "total": {
+                          "description": "Total tokens consumed",
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "recording",
+                        "transcription",
+                        "byok_transcription",
+                        "streaming_input",
+                        "streaming_output",
+                        "total"
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               },
               "required": [
@@ -879,7 +924,8 @@
                 "exited_at",
                 "status",
                 "error_code",
-                "error_message"
+                "error_message",
+                "tokens"
               ]
             }
           },
@@ -1232,6 +1278,51 @@
                   }
                 ]
               },
+              "tokens": {
+                "description": "Token consumption breakdown (null if not yet consumed)",
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "recording": {
+                        "description": "Recording tokens consumed",
+                        "type": "number"
+                      },
+                      "transcription": {
+                        "description": "Transcription tokens consumed",
+                        "type": "number"
+                      },
+                      "byok_transcription": {
+                        "description": "BYOK transcription tokens consumed",
+                        "type": "number"
+                      },
+                      "streaming_input": {
+                        "description": "Streaming input tokens consumed",
+                        "type": "number"
+                      },
+                      "streaming_output": {
+                        "description": "Streaming output tokens consumed",
+                        "type": "number"
+                      },
+                      "total": {
+                        "description": "Total tokens consumed",
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "recording",
+                      "transcription",
+                      "byok_transcription",
+                      "streaming_input",
+                      "streaming_output",
+                      "total"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "extra": {
                 "description": "Custom metadata associated with the bot",
                 "anyOf": [
@@ -1331,6 +1422,7 @@
               "transcription_provider",
               "error_code",
               "error_message",
+              "tokens",
               "extra",
               "zoom_config"
             ]
@@ -7586,6 +7678,52 @@
                       "type": "null"
                     }
                   ]
+                },
+                "tokens": {
+                  "description": "Token consumption breakdown (null if not yet consumed)",
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "recording": {
+                          "description": "Recording tokens consumed",
+                          "type": "number"
+                        },
+                        "transcription": {
+                          "description": "Transcription tokens consumed",
+                          "type": "number"
+                        },
+                        "byok_transcription": {
+                          "description": "BYOK transcription tokens consumed",
+                          "type": "number"
+                        },
+                        "streaming_input": {
+                          "description": "Streaming input tokens consumed",
+                          "type": "number"
+                        },
+                        "streaming_output": {
+                          "description": "Streaming output tokens consumed",
+                          "type": "number"
+                        },
+                        "total": {
+                          "description": "Total tokens consumed",
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "recording",
+                        "transcription",
+                        "byok_transcription",
+                        "streaming_input",
+                        "streaming_output",
+                        "total"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 }
               },
               "required": [
@@ -7601,7 +7739,8 @@
                 "exited_at",
                 "status",
                 "error_code",
-                "error_message"
+                "error_message",
+                "tokens"
               ],
               "additionalProperties": false
             }
@@ -7958,6 +8097,52 @@
                   }
                 ]
               },
+              "tokens": {
+                "description": "Token consumption breakdown (null if not yet consumed)",
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "recording": {
+                        "description": "Recording tokens consumed",
+                        "type": "number"
+                      },
+                      "transcription": {
+                        "description": "Transcription tokens consumed",
+                        "type": "number"
+                      },
+                      "byok_transcription": {
+                        "description": "BYOK transcription tokens consumed",
+                        "type": "number"
+                      },
+                      "streaming_input": {
+                        "description": "Streaming input tokens consumed",
+                        "type": "number"
+                      },
+                      "streaming_output": {
+                        "description": "Streaming output tokens consumed",
+                        "type": "number"
+                      },
+                      "total": {
+                        "description": "Total tokens consumed",
+                        "type": "number"
+                      }
+                    },
+                    "required": [
+                      "recording",
+                      "transcription",
+                      "byok_transcription",
+                      "streaming_input",
+                      "streaming_output",
+                      "total"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "extra": {
                 "description": "Custom metadata associated with the bot",
                 "anyOf": [
@@ -8058,6 +8243,7 @@
               "transcription_provider",
               "error_code",
               "error_message",
+              "tokens",
               "extra",
               "zoom_config"
             ],
@@ -14231,6 +14417,24 @@
             "name": "bot_name",
             "required": false,
             "description": "Filter bots by name containing this string.\n\nPerforms a case-insensitive partial match on the bot's name. Useful for finding bots with specific naming conventions or to locate a particular bot when you don't have its ID.\n\nExample: \"Sales\" would match \"Sales Meeting\", \"Quarterly Sales\", etc."
+          },
+          {
+            "schema": {
+              "example": null,
+              "default": null,
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "in": "query",
+            "name": "participant_name",
+            "required": false,
+            "description": "Filter bots by participant name.\n\nPerforms a case-insensitive partial match on participant names in the meeting.\n\nExample: \"John\" would match meetings where \"John Smith\" participated."
           },
           {
             "schema": {

--- a/openapi.json
+++ b/openapi.json
@@ -378,7 +378,7 @@
           "Webhooks"
         ],
         "summary": "Webhook Events Documentation",
-        "description": "Meeting BaaS sends webhook events to your configured webhook URL when specific events occur.\n\n## Webhook Event Types\n\n### 1. `complete`\nSent when a bot successfully completes recording a meeting. Contains full transcription data and a link to the recording.\n```json\n{\n  \\\"event\\\": \\\"complete\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\",\n    \\\"event_uuid\\\": \\\"123e4567-e89b-12d3-a456-426614174001\\\",\n    \\\"transcript\\\": [\n      {\n        \\\"speaker\\\": \\\"John Doe\\\",\n        \\\"offset\\\": 1.5,\n        \\\"start_time\\\": 1.5,\n        \\\"end_time\\\": 2.4,\n        \\\"words\\\": [\n          {\n            \\\"start\\\": 1.5,\n            \\\"end\\\": 1.9,\n            \\\"word\\\": \\\"Hello\\\"\n          },\n          {\n            \\\"start\\\": 2.0,\n            \\\"end\\\": 2.4,\n            \\\"word\\\": \\\"everyone\\\"\n          }\n        ]\n      }\n    ],\n    \\\"speakers\\\": [\n      \\\"John Doe\\\",\n      \\\"Jane Smith\\\"\n    ],\n    \\\"mp4\\\": \\\"https://storage.example.com/recordings/video123.mp4?token=abc\\\",\n    \\\"audio\\\": \\\"https://storage.example.com/recordings/audio123.wav?token=abc\\\",\n    \\\"event\\\": \\\"complete\\\",\n    \\\"extra\\\": {\n      \\\"foo\\\": \\\"bar\\\"\n    }\n  }\n}\n```\n\nThe `complete` event includes:\n- **bot_id**: Unique identifier for the bot that completed recording\n- **event_uuid**: UUID of the calendar event (if this bot was created from an event)\n- **speakers**: A set of speaker names identified in the meeting\n- **transcript**: Full transcript data with speaker identification and word timing\n- **mp4**: URL to the recording file (valid for 24 hours by default)\n- **event**: Event type identifier (\"complete\")\n\n### 2. `failed`\nSent when a bot fails to join or record a meeting. Contains error details.\n```json\n{\n  \\\"event\\\": \\\"failed\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\",\n    \\\"event_uuid\\\": \\\"123e4567-e89b-12d3-a456-426614174001\\\",\n    \\\"error\\\": \\\"meeting_not_found\\\",\n    \\\"message\\\": \\\"Could not join meeting: The meeting ID was not found or has expired\\\",\n    \\\"extra\\\": {\n      \\\"foo\\\": \\\"bar\\\"\n    }\n  }\n}\n```\n\nThe `failed` event includes:\n- **bot_id**: Unique identifier for the bot that failed\n- **event_uuid**: UUID of the calendar event (if this bot was created from an event)\n- **error**: Error code identifying the type of failure\n- **message**: Detailed human-readable error message\n\nCommon error types include:\n- `meeting_not_found`: The meeting ID or link was invalid or expired\n- `access_denied`: The bot was denied access to the meeting\n- `authentication_error`: Failed to authenticate with the meeting platform\n- `network_error`: Network connectivity issues during recording\n- `internal_error`: Internal server error\n\n### 3. `calendar.sync_events`\nSent when calendar events are synced. Contains information about which events were updated.\n```json\n{\n  \\\"event\\\": \\\"calendar.sync_events\\\",\n  \\\"data\\\": {\n    \\\"calendar_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\",\n    \\\"last_updated_ts\\\": \\\"2023-05-01T12:00:00Z\\\",\n    \\\"affected_event_uuids\\\": [\n      \\\"123e4567-e89b-12d3-a456-426614174001\\\",\n      \\\"123e4567-e89b-12d3-a456-426614174002\\\"\n    ]\n  }\n}\n```\n\nThe `calendar.sync_events` event includes:\n- **calendar_id**: UUID of the calendar that was synced\n- **last_updated_ts**: ISO-8601 timestamp of when the sync occurred\n- **affected_event_uuids**: Array of UUIDs for calendar events that were added, updated, or deleted\n\nThis event is triggered when:\n- Calendar data is synced with the external provider (Google, Microsoft)\n- Multiple events may be created, updated, or deleted in a single sync operation\n- Use this event to update your local cache of calendar events\n\n### 4. `transcription_complete`\nSent when transcription is completed separately from recording (e.g., after retranscribing).\n```json\n{\n  \\\"event\\\": \\\"transcription_complete\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\"\n  }\n}\n```\n\nThe `transcription_complete` event includes:\n- **bot_id**: Unique identifier for the bot with the completed transcription\n\nThis event is sent when:\n- You request a retranscription via the `/bots/retranscribe` endpoint\n- An asynchronous transcription process completes after the recording has ended\n\n## Setting Up Webhooks\n\nYou can configure webhooks in two ways:\n1. **Account-level webhook URL**: Set a default webhook URL for all bots in your account using the `/accounts/webhook_url` endpoint\n2. **Bot-specific webhook URL**: Provide a `webhook_url` parameter when creating a bot with the `/bots` endpoint\n\nYour webhook endpoint must:\n- Accept POST requests with JSON payload\n- Return a 2xx status code to acknowledge receipt\n- Process requests within 10 seconds to avoid timeouts\n- Handle each event type appropriately based on the event type\n\nAll webhook requests include:\n- `x-meeting-baas-api-key` header with your API key for verification\n- `content-type: application/json` header\n- JSON body containing the event details\n\n## Webhook Reliability\n\nIf your endpoint fails to respond or returns an error, the system will attempt to retry the webhook delivery. For critical events, we recommend implementing:\n\n- Idempotency handling to prevent duplicate processing of the same event\n- Proper logging of webhook receipts for audit purposes\n- Asynchronous processing to quickly acknowledge receipt before handling the event data\n\nFor security, always validate the API key in the `x-meeting-baas-api-key` header matches your API key.",
+        "description": "Meeting BaaS sends webhook events to your configured webhook URL when specific events occur.\n\n## Webhook Event Types\n\n### 1. `complete`\nSent when a bot successfully completes recording a meeting. Contains full transcription data and a link to the recording.\n```json\n{\n  \\\"event\\\": \\\"complete\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\",\n    \\\"event_uuid\\\": \\\"123e4567-e89b-12d3-a456-426614174001\\\",\n    \\\"transcript\\\": [\n      {\n        \\\"speaker\\\": \\\"John Doe\\\",\n        \\\"offset\\\": 1.5,\n        \\\"start_time\\\": 1.5,\n        \\\"end_time\\\": 2.4,\n        \\\"words\\\": [\n          {\n            \\\"start\\\": 1.5,\n            \\\"end\\\": 1.9,\n            \\\"word\\\": \\\"Hello\\\"\n          },\n          {\n            \\\"start\\\": 2.0,\n            \\\"end\\\": 2.4,\n            \\\"word\\\": \\\"everyone\\\"\n          }\n        ]\n      }\n    ],\n    \\\"speakers\\\": [\n      \\\"Jane Smith\\\",\n      \\\"John Doe\\\"\n    ],\n    \\\"mp4\\\": \\\"https://storage.example.com/recordings/video123.mp4?token=abc\\\",\n    \\\"audio\\\": \\\"https://storage.example.com/recordings/audio123.wav?token=abc\\\",\n    \\\"event\\\": \\\"complete\\\",\n    \\\"extra\\\": {\n      \\\"foo\\\": \\\"bar\\\"\n    }\n  }\n}\n```\n\nThe `complete` event includes:\n- **bot_id**: Unique identifier for the bot that completed recording\n- **event_uuid**: UUID of the calendar event (if this bot was created from an event)\n- **speakers**: A set of speaker names identified in the meeting\n- **transcript**: Full transcript data with speaker identification and word timing\n- **mp4**: URL to the recording file (valid for 24 hours by default)\n- **event**: Event type identifier (\"complete\")\n\n### 2. `failed`\nSent when a bot fails to join or record a meeting. Contains error details.\n```json\n{\n  \\\"event\\\": \\\"failed\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\",\n    \\\"event_uuid\\\": \\\"123e4567-e89b-12d3-a456-426614174001\\\",\n    \\\"error\\\": \\\"meeting_not_found\\\",\n    \\\"message\\\": \\\"Could not join meeting: The meeting ID was not found or has expired\\\",\n    \\\"extra\\\": {\n      \\\"foo\\\": \\\"bar\\\"\n    }\n  }\n}\n```\n\nThe `failed` event includes:\n- **bot_id**: Unique identifier for the bot that failed\n- **event_uuid**: UUID of the calendar event (if this bot was created from an event)\n- **error**: Error code identifying the type of failure\n- **message**: Detailed human-readable error message\n\nCommon error types include:\n- `meeting_not_found`: The meeting ID or link was invalid or expired\n- `access_denied`: The bot was denied access to the meeting\n- `authentication_error`: Failed to authenticate with the meeting platform\n- `network_error`: Network connectivity issues during recording\n- `internal_error`: Internal server error\n\n### 3. `calendar.sync_events`\nSent when calendar events are synced. Contains information about which events were updated.\n```json\n{\n  \\\"event\\\": \\\"calendar.sync_events\\\",\n  \\\"data\\\": {\n    \\\"calendar_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\",\n    \\\"last_updated_ts\\\": \\\"2023-05-01T12:00:00Z\\\",\n    \\\"affected_event_uuids\\\": [\n      \\\"123e4567-e89b-12d3-a456-426614174001\\\",\n      \\\"123e4567-e89b-12d3-a456-426614174002\\\"\n    ]\n  }\n}\n```\n\nThe `calendar.sync_events` event includes:\n- **calendar_id**: UUID of the calendar that was synced\n- **last_updated_ts**: ISO-8601 timestamp of when the sync occurred\n- **affected_event_uuids**: Array of UUIDs for calendar events that were added, updated, or deleted\n\nThis event is triggered when:\n- Calendar data is synced with the external provider (Google, Microsoft)\n- Multiple events may be created, updated, or deleted in a single sync operation\n- Use this event to update your local cache of calendar events\n\n### 4. `transcription_complete`\nSent when transcription is completed separately from recording (e.g., after retranscribing).\n```json\n{\n  \\\"event\\\": \\\"transcription_complete\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\"\n  }\n}\n```\n\nThe `transcription_complete` event includes:\n- **bot_id**: Unique identifier for the bot with the completed transcription\n\nThis event is sent when:\n- You request a retranscription via the `/bots/retranscribe` endpoint\n- An asynchronous transcription process completes after the recording has ended\n\n## Setting Up Webhooks\n\nYou can configure webhooks in two ways:\n1. **Account-level webhook URL**: Set a default webhook URL for all bots in your account using the `/accounts/webhook_url` endpoint\n2. **Bot-specific webhook URL**: Provide a `webhook_url` parameter when creating a bot with the `/bots` endpoint\n\nYour webhook endpoint must:\n- Accept POST requests with JSON payload\n- Return a 2xx status code to acknowledge receipt\n- Process requests within 10 seconds to avoid timeouts\n- Handle each event type appropriately based on the event type\n\nAll webhook requests include:\n- `x-meeting-baas-api-key` header with your API key for verification\n- `content-type: application/json` header\n- JSON body containing the event details\n\n## Webhook Reliability\n\nIf your endpoint fails to respond or returns an error, the system will attempt to retry the webhook delivery. For critical events, we recommend implementing:\n\n- Idempotency handling to prevent duplicate processing of the same event\n- Proper logging of webhook receipts for audit purposes\n- Asynchronous processing to quickly acknowledge receipt before handling the event data\n\nFor security, always validate the API key in the `x-meeting-baas-api-key` header matches your API key.",
         "operationId": "webhook_documentation",
         "responses": {
           "200": {
@@ -398,7 +398,7 @@
           "Webhooks"
         ],
         "summary": "Bot Webhook Events Documentation",
-        "description": "Meeting BaaS sends the following webhook events related to bot recordings.\n\n## Bot Webhook Event Types\n\n### 1. `complete`\nSent when a bot successfully completes recording a meeting.\n\n**Payload Structure:**\n```json\n{\n  \\\"event\\\": \\\"complete\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\",\n    \\\"event_uuid\\\": \\\"123e4567-e89b-12d3-a456-426614174001\\\",\n    \\\"transcript\\\": [\n      {\n        \\\"speaker\\\": \\\"John Doe\\\",\n        \\\"offset\\\": 1.5,\n        \\\"start_time\\\": 1.5,\n        \\\"end_time\\\": 2.4,\n        \\\"words\\\": [\n          {\n            \\\"start\\\": 1.5,\n            \\\"end\\\": 1.9,\n            \\\"word\\\": \\\"Hello\\\"\n          },\n          {\n            \\\"start\\\": 2.0,\n            \\\"end\\\": 2.4,\n            \\\"word\\\": \\\"everyone\\\"\n          }\n        ]\n      }\n    ],\n    \\\"speakers\\\": [\n      \\\"Jane Smith\\\",\n      \\\"John Doe\\\"\n    ],\n    \\\"mp4\\\": \\\"https://storage.example.com/recordings/video123.mp4?token=abc\\\",\n    \\\"audio\\\": \\\"https://storage.example.com/recordings/audio123.wav?token=abc\\\",\n    \\\"event\\\": \\\"complete\\\",\n    \\\"extra\\\": {\n      \\\"foo\\\": \\\"bar\\\"\n    }\n  }\n}\n```\n\n**When it's triggered:**\n- After a bot successfully records and processes a meeting\n- After the recording is uploaded and made available\n- When all processing of the meeting recording is complete\n\n**What to do with it:**\n- Download the MP4 recording for storage in your system\n- Store the transcript data in your database\n- Update meeting status in your application\n- Notify users that the recording is available\n- Use `event_uuid` to correlate with calendar events (if applicable)\n\n### 2. `failed`\nSent when a bot fails to join or record a meeting.\n\n**Payload Structure:**\n```json\n{\n  \\\"event\\\": \\\"failed\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\",\n    \\\"event_uuid\\\": \\\"123e4567-e89b-12d3-a456-426614174001\\\",\n    \\\"error\\\": \\\"meeting_not_found\\\",\n    \\\"message\\\": \\\"Could not join meeting: The meeting ID was not found or has expired\\\",\n    \\\"extra\\\": {\n      \\\"foo\\\": \\\"bar\\\"\n    }\n  }\n}\n```\n\n**Common error types:**\n- `meeting_not_found`: The meeting ID or link was invalid or expired\n- `access_denied`: The bot was denied access to the meeting\n- `authentication_error`: Failed to authenticate with the meeting platform\n- `network_error`: Network connectivity issues during recording\n- `internal_error`: Internal server error\n\n**What to do with it:**\n- Log the failure for troubleshooting\n- Notify administrators or users about the failed recording\n- Attempt to reschedule if appropriate\n- Update meeting status in your system\n- Use `event_uuid` to correlate with calendar events (if applicable)\n\n### 3. `transcription_complete`\nSent when transcription is completed separately from recording.\n\n**Payload Structure:**\n```json\n{\n  \\\"event\\\": \\\"transcription_complete\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\"\n  }\n}\n```\n\n**When it's triggered:**\n- After requesting retranscription via the API\n- When an asynchronous transcription job completes\n- When a higher quality or different language transcription becomes available\n\n**What to do with it:**\n- Update the transcript data in your system\n- Notify users that improved transcription is available\n- Run any post-processing on the new transcript data\n\n## Webhook Usage Tips\n\n- Each event includes the `bot_id` so you can correlate with your internal data\n- The `event_uuid` field is included when the bot was created from a calendar event (null for direct bots or scheduled bots)\n- The complete event includes speaker identification and full transcript data\n- For downloading recordings, the mp4 URL is valid for 24 hours\n- Handle the webhook asynchronously and return 200 OK quickly to prevent timeouts\n\nFor security, always validate the API key in the `x-meeting-baas-api-key` header matches your API key.",
+        "description": "Meeting BaaS sends the following webhook events related to bot recordings.\n\n## Bot Webhook Event Types\n\n### 1. `complete`\nSent when a bot successfully completes recording a meeting.\n\n**Payload Structure:**\n```json\n{\n  \\\"event\\\": \\\"complete\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\",\n    \\\"event_uuid\\\": \\\"123e4567-e89b-12d3-a456-426614174001\\\",\n    \\\"transcript\\\": [\n      {\n        \\\"speaker\\\": \\\"John Doe\\\",\n        \\\"offset\\\": 1.5,\n        \\\"start_time\\\": 1.5,\n        \\\"end_time\\\": 2.4,\n        \\\"words\\\": [\n          {\n            \\\"start\\\": 1.5,\n            \\\"end\\\": 1.9,\n            \\\"word\\\": \\\"Hello\\\"\n          },\n          {\n            \\\"start\\\": 2.0,\n            \\\"end\\\": 2.4,\n            \\\"word\\\": \\\"everyone\\\"\n          }\n        ]\n      }\n    ],\n    \\\"speakers\\\": [\n      \\\"John Doe\\\",\n      \\\"Jane Smith\\\"\n    ],\n    \\\"mp4\\\": \\\"https://storage.example.com/recordings/video123.mp4?token=abc\\\",\n    \\\"audio\\\": \\\"https://storage.example.com/recordings/audio123.wav?token=abc\\\",\n    \\\"event\\\": \\\"complete\\\",\n    \\\"extra\\\": {\n      \\\"foo\\\": \\\"bar\\\"\n    }\n  }\n}\n```\n\n**When it's triggered:**\n- After a bot successfully records and processes a meeting\n- After the recording is uploaded and made available\n- When all processing of the meeting recording is complete\n\n**What to do with it:**\n- Download the MP4 recording for storage in your system\n- Store the transcript data in your database\n- Update meeting status in your application\n- Notify users that the recording is available\n- Use `event_uuid` to correlate with calendar events (if applicable)\n\n### 2. `failed`\nSent when a bot fails to join or record a meeting.\n\n**Payload Structure:**\n```json\n{\n  \\\"event\\\": \\\"failed\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\",\n    \\\"event_uuid\\\": \\\"123e4567-e89b-12d3-a456-426614174001\\\",\n    \\\"error\\\": \\\"meeting_not_found\\\",\n    \\\"message\\\": \\\"Could not join meeting: The meeting ID was not found or has expired\\\",\n    \\\"extra\\\": {\n      \\\"foo\\\": \\\"bar\\\"\n    }\n  }\n}\n```\n\n**Common error types:**\n- `meeting_not_found`: The meeting ID or link was invalid or expired\n- `access_denied`: The bot was denied access to the meeting\n- `authentication_error`: Failed to authenticate with the meeting platform\n- `network_error`: Network connectivity issues during recording\n- `internal_error`: Internal server error\n\n**What to do with it:**\n- Log the failure for troubleshooting\n- Notify administrators or users about the failed recording\n- Attempt to reschedule if appropriate\n- Update meeting status in your system\n- Use `event_uuid` to correlate with calendar events (if applicable)\n\n### 3. `transcription_complete`\nSent when transcription is completed separately from recording.\n\n**Payload Structure:**\n```json\n{\n  \\\"event\\\": \\\"transcription_complete\\\",\n  \\\"data\\\": {\n    \\\"bot_id\\\": \\\"123e4567-e89b-12d3-a456-426614174000\\\"\n  }\n}\n```\n\n**When it's triggered:**\n- After requesting retranscription via the API\n- When an asynchronous transcription job completes\n- When a higher quality or different language transcription becomes available\n\n**What to do with it:**\n- Update the transcript data in your system\n- Notify users that improved transcription is available\n- Run any post-processing on the new transcript data\n\n## Webhook Usage Tips\n\n- Each event includes the `bot_id` so you can correlate with your internal data\n- The `event_uuid` field is included when the bot was created from a calendar event (null for direct bots or scheduled bots)\n- The complete event includes speaker identification and full transcript data\n- For downloading recordings, the mp4 URL is valid for 24 hours\n- Handle the webhook asynchronously and return 200 OK quickly to prevent timeouts\n\nFor security, always validate the API key in the `x-meeting-baas-api-key` header matches your API key.",
         "operationId": "bot_webhook_documentation",
         "responses": {
           "200": {
@@ -1329,6 +1329,7 @@
           "diarization_v2",
           "ended_at",
           "id",
+          "is_stopped",
           "meeting_url",
           "mp4_s3_path",
           "reserved",
@@ -1382,6 +1383,9 @@
             "type": "integer",
             "format": "int32"
           },
+          "is_stopped": {
+            "type": "boolean"
+          },
           "meeting_url": {
             "type": "string"
           },
@@ -1416,6 +1420,51 @@
           "uuid": {
             "type": "string",
             "format": "uuid"
+          }
+        }
+      },
+      "BotCrashedQuery": {
+        "type": "object",
+        "required": [
+          "bot_uuid"
+        ],
+        "properties": {
+          "bot_uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "BotCrashedRequest": {
+        "type": "object",
+        "required": [
+          "crashReason"
+        ],
+        "properties": {
+          "crashReason": {
+            "type": "string"
+          },
+          "efsManifest": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/EfsManifestEntry"
+            }
+          },
+          "exitCode": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
+          "signal": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
           }
         }
       },
@@ -1967,6 +2016,7 @@
           "ended_at",
           "extra",
           "id",
+          "is_stopped",
           "meeting_url",
           "mp4_s3_path",
           "reserved",
@@ -2045,6 +2095,9 @@
           "id": {
             "type": "integer",
             "format": "int32"
+          },
+          "is_stopped": {
+            "type": "boolean"
           },
           "meeting_url": {
             "type": "string"
@@ -2400,6 +2453,28 @@
           }
         }
       },
+      "CheckStopRequestQuery": {
+        "type": "object",
+        "required": [
+          "bot_uuid"
+        ],
+        "properties": {
+          "bot_uuid": {
+            "type": "string"
+          }
+        }
+      },
+      "CheckStopRequestResponse": {
+        "type": "object",
+        "required": [
+          "is_stopped"
+        ],
+        "properties": {
+          "is_stopped": {
+            "type": "boolean"
+          }
+        }
+      },
       "CreateCalendarParams": {
         "type": "object",
         "required": [
@@ -2534,6 +2609,23 @@
             ]
           }
         ]
+      },
+      "EfsManifestEntry": {
+        "type": "object",
+        "required": [
+          "path",
+          "size"
+        ],
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0
+          }
+        }
       },
       "EndMeetingQuery": {
         "type": "object",
@@ -3410,7 +3502,7 @@
           },
           "last_updated": {
             "description": "Timestamp of when this data was generated (in ISO-8601 format)\n\nThis field is maintained for backwards compatibility. It is automatically set to the current time when the response is created.",
-            "default": "2026-02-15T12:57:58.007290999+00:00",
+            "default": "2026-04-04T12:29:32.375074809+00:00",
             "type": "string",
             "format": "date-time"
           },
@@ -4582,6 +4674,9 @@
           "zoom_user_id"
         ],
         "properties": {
+          "connection_failure_data": {
+            "description": "Details about why the connection failed. Only present when `state` is `refresh_failed`."
+          },
           "created_at": {
             "description": "Timestamp when the connection was first created.",
             "type": "string",
@@ -4595,7 +4690,7 @@
             ]
           },
           "state": {
-            "description": "Connection state. `connected` means tokens are valid; `disconnected` means the user needs to re-authorize.",
+            "description": "Connection state. `connected` means tokens are valid; `refresh_failed` means the token refresh failed and the user needs to re-authorize.",
             "type": "string"
           },
           "updated_at": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because the OpenAPI specs change response shapes (adds required `tokens`) and add a new query filter, which can affect generated clients and existing integrations expecting the previous schema.
> 
> **Overview**
> Adds a new v2 docs page for **Alerts** (operational + threshold rules, cooldown/suppression behavior, email + callback delivery payload/headers, and limits) and links it into the v2 docs navigation.
> 
> Expands the v2 **Webhooks** docs with an explicit SVIX retry schedule, timeout/429 behavior, and endpoint auto-disable semantics tied to a `webhook_delivery_exhausted` alert; also clarifies callback retry rules and manual retry behavior.
> 
> Updates API/reference artifacts: OpenAPI v2 bot schemas now include a (required) `tokens` consumption breakdown, `GET /v2/bots` supports a new `participant_name` filter, and legacy OpenAPI adds `is_stopped`, crash/stop-related schemas, and Zoom OAuth connection failure metadata; generated webhook docs/LLM markdown are regenerated (including minor speaker ordering tweaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a8f6f052c61bb9b5a7e3dcc9e8b944206f70e9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->