### PR TITLE
Migrate from @oramacloud/client to @orama/core

### DIFF
--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -174,6 +174,9 @@ jobs:
         env:
           NEXT_PUBLIC_ORAMA_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_ORAMA_PROJECT_ID }}
           NEXT_PUBLIC_ORAMA_API_KEY: ${{ secrets.NEXT_PUBLIC_ORAMA_API_KEY }}
+          ORAMA_PRIVATE_API_KEY: ${{ secrets.ORAMA_PRIVATE_API_KEY }}
+          ORAMA_SEARCH_INDEX_ID: ${{ secrets.ORAMA_SEARCH_INDEX_ID }}
+          ORAMA_AI_INDEX_ID: ${{ secrets.ORAMA_AI_INDEX_ID }}
 
       - name: Upload artifacts
         if: steps.fetch-spec.outputs.has_changes == 'true' && steps.check-prs.outputs.create_pr == 'true'

--- a/.github/workflows/update-openapi.yml
+++ b/.github/workflows/update-openapi.yml
@@ -150,10 +150,8 @@ jobs:
             --head "$BRANCH_NAME"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEXT_PUBLIC_ORAMA_AI_API_KEY: ${{ secrets.NEXT_PUBLIC_ORAMA_AI_API_KEY }}
-          NEXT_PUBLIC_ORAMA_AI_ENDPOINT: ${{ secrets.NEXT_PUBLIC_ORAMA_AI_ENDPOINT }}
-          NEXT_PUBLIC_ORAMA_SEARCH_API_KEY: ${{ secrets.NEXT_PUBLIC_ORAMA_SEARCH_API_KEY }}
-          NEXT_PUBLIC_ORAMA_SEARCH_ENDPOINT: ${{ secrets.NEXT_PUBLIC_ORAMA_SEARCH_ENDPOINT }}
+          NEXT_PUBLIC_ORAMA_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_ORAMA_PROJECT_ID }}
+          NEXT_PUBLIC_ORAMA_API_KEY: ${{ secrets.NEXT_PUBLIC_ORAMA_API_KEY }}
 
       - name: Comment on existing PR
         if: steps.fetch-spec.outputs.has_changes == 'true' && steps.check-prs.outputs.create_pr == 'false'
@@ -174,10 +172,8 @@ jobs:
           # Build commands (use full build script)
           pnpm build
         env:
-          NEXT_PUBLIC_ORAMA_AI_API_KEY: ${{ secrets.NEXT_PUBLIC_ORAMA_AI_API_KEY }}
-          NEXT_PUBLIC_ORAMA_AI_ENDPOINT: ${{ secrets.NEXT_PUBLIC_ORAMA_AI_ENDPOINT }}
-          NEXT_PUBLIC_ORAMA_SEARCH_API_KEY: ${{ secrets.NEXT_PUBLIC_ORAMA_SEARCH_API_KEY }}
-          NEXT_PUBLIC_ORAMA_SEARCH_ENDPOINT: ${{ secrets.NEXT_PUBLIC_ORAMA_SEARCH_ENDPOINT }}
+          NEXT_PUBLIC_ORAMA_PROJECT_ID: ${{ secrets.NEXT_PUBLIC_ORAMA_PROJECT_ID }}
+          NEXT_PUBLIC_ORAMA_API_KEY: ${{ secrets.NEXT_PUBLIC_ORAMA_API_KEY }}
 
       - name: Upload artifacts
         if: steps.fetch-spec.outputs.has_changes == 'true' && steps.check-prs.outputs.create_pr == 'true'

--- a/components/fumadocs/ai/engines/orama.ts
+++ b/components/fumadocs/ai/engines/orama.ts
@@ -3,74 +3,102 @@ import type {
   MessageRecord,
   MessageReference,
 } from '@/components/fumadocs/ai/context';
-import { OramaClient } from '@oramacloud/client';
+import { OramaCloud } from '@orama/core';
 
-const context =
-  "The user is a web developer who has basic programming knowledge, and has questions about MeetingBaas's APIs.";
-const endpoint = process.env.NEXT_PUBLIC_ORAMA_AI_ENDPOINT;
-const apiKey = process.env.NEXT_PUBLIC_ORAMA_AI_API_KEY;
+const projectId = process.env.NEXT_PUBLIC_ORAMA_PROJECT_ID;
+const apiKey = process.env.NEXT_PUBLIC_ORAMA_API_KEY;
 
 export async function createOramaEngine(): Promise<Engine> {
-  if (!endpoint || !apiKey) throw new Error('Failed to find api keys');
-  const client = new OramaClient({
-    endpoint,
-    api_key: apiKey,
-  });
+  if (!projectId || !apiKey) throw new Error('Failed to find api keys');
 
-  const instance = client.createAnswerSession({
-    userContext: context,
-    inferenceType: 'documentation',
+  const client = new OramaCloud({ projectId, apiKey });
+
+  const session = client.ai.createAISession({
     events: {
-      onSourceChange(sources) {
-        const last = instance.getMessages().at(-1);
-
-        if (last) {
-          (last as MessageRecord).references = (
-            sources as unknown as typeof sources.hits
-          ).map((result) => result.document as MessageReference);
-        }
-      },
-      onRelatedQueries(queries) {
-        const last = instance.getMessages().at(-1);
-
-        if (last) {
-          (last as MessageRecord).suggestions = queries;
-        }
+      onStateChange() {
+        // State updates (sources, related queries) are read in getHistory()
       },
     },
   });
 
   return {
     async prompt(text, onUpdate, onEnd) {
-      let v = '';
-      const stream = await instance.askStream({
-        term: text,
-      });
+      let full = '';
+      const stream = session.answerStream({ query: text });
 
-      for await (const block of stream) {
-        v = block;
-        onUpdate?.(block);
+      for await (const chunk of stream) {
+        full = chunk;
+        onUpdate?.(chunk);
       }
-      onEnd?.(v);
+      onEnd?.(full);
     },
     abortAnswer() {
-      instance.abortAnswer();
+      session.abort();
     },
-    getHistory() {
-      return instance.getMessages();
+    getHistory(): MessageRecord[] {
+      const records: MessageRecord[] = [];
+      let interactionIdx = 0;
+
+      for (const msg of session.messages) {
+        if (msg.role === 'system') continue;
+
+        const record: MessageRecord = {
+          role: msg.role as 'user' | 'assistant',
+          content: msg.content,
+        };
+
+        if (msg.role === 'assistant') {
+          const interaction = session.state[interactionIdx];
+          if (interaction) {
+            if (interaction.sources) {
+              const sources = interaction.sources as any;
+              const hits: any[] = Array.isArray(sources) ? sources : [];
+              record.references = hits.map((result: any) => {
+                const doc = result.document ?? result;
+                return {
+                  title: doc.title ?? '',
+                  description: doc.description,
+                  url: doc.url ?? '',
+                  breadcrumbs: doc.breadcrumbs,
+                } as MessageReference;
+              });
+            }
+            if (interaction.related) {
+              try {
+                const related =
+                  typeof interaction.related === 'string'
+                    ? JSON.parse(interaction.related)
+                    : interaction.related;
+                record.suggestions = Array.isArray(related)
+                  ? related
+                  : [String(related)];
+              } catch {
+                record.suggestions = [interaction.related];
+              }
+            }
+          }
+          interactionIdx++;
+        }
+
+        records.push(record);
+      }
+
+      return records;
     },
     clearHistory() {
-      instance.clearSession();
+      session.clearSession();
     },
     async regenerateLast(onUpdate, onEnd) {
-      const result = await instance.regenerateLast({ stream: true });
-      let v = '';
+      const result = session.regenerateLast({
+        stream: true,
+      }) as AsyncGenerator<string>;
+      let full = '';
 
-      for await (const block of result) {
-        v = block;
-        onUpdate?.(block);
+      for await (const chunk of result) {
+        full = chunk;
+        onUpdate?.(chunk);
       }
-      onEnd?.(v);
+      onEnd?.(full);
     },
   };
 }

--- a/components/search.tsx
+++ b/components/search.tsx
@@ -1,21 +1,20 @@
-import { OramaClient } from '@oramacloud/client';
+import { OramaCloud } from '@orama/core';
 import type { SharedProps } from 'fumadocs-ui/components/dialog/search';
 import SearchDialog from 'fumadocs-ui/components/dialog/search-orama';
 import { useMode } from '@/app/layout.client';
 
-// Check if environment variables are defined
-const endpoint = process.env.NEXT_PUBLIC_ORAMA_SEARCH_ENDPOINT;
-const apiKey = process.env.NEXT_PUBLIC_ORAMA_SEARCH_API_KEY;
+const projectId = process.env.NEXT_PUBLIC_ORAMA_PROJECT_ID;
+const apiKey = process.env.NEXT_PUBLIC_ORAMA_API_KEY;
 
-if (!endpoint || !apiKey) {
+if (!projectId || !apiKey) {
   throw new Error(
-    'Orama search endpoint and API key must be defined in environment variables',
+    'Orama project ID and API key must be defined in environment variables',
   );
 }
 
-const client = new OramaClient({
-  endpoint,
-  api_key: apiKey,
+const client = new OramaCloud({
+  projectId,
+  apiKey,
 });
 
 export default function CustomSearchDialog(

--- a/components/search.tsx
+++ b/components/search.tsx
@@ -31,21 +31,9 @@ export default function CustomSearchDialog(
           value: 'api',
         },
         {
-          name: 'Transcript Seeker',
-          value: 'transcript-seeker',
+          name: 'API v2',
+          value: 'api-v2',
         },
-        {
-          name: 'Speaking Bots',
-          value: 'speaking-bots',
-        },
-        {
-          name: 'Typescript SDK',
-          value: 'typescript-sdk',
-        },
-        {
-          name: 'MCP Servers',
-          value: 'mcp-servers'
-        }
       ]}
       client={client}
       showOrama

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@inkeep/ai-api": "^0.8.0",
     "@meeting-baas/sdk": "^5.0.0",
     "@openrouter/ai-sdk-provider": "^0.4.5",
-    "@oramacloud/client": "^2.1.4",
+    "@orama/core": "^1.2.19",
     "@radix-ui/react-accordion": "^1.2.8",
     "@radix-ui/react-collapsible": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 1.2.4(zod@4.3.6)
       '@fumadocs/mdx-remote':
         specifier: ^1.4.4
-        version: 1.4.4(@types/react@19.1.0)(fumadocs-core@16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(react@19.2.1)
+        version: 1.4.4(@types/react@19.1.0)(fumadocs-core@16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(react@19.2.1)
       '@inkeep/ai-api':
         specifier: ^0.8.0
         version: 0.8.0(zod@4.3.6)
@@ -29,9 +29,9 @@ importers:
       '@openrouter/ai-sdk-provider':
         specifier: ^0.4.5
         version: 0.4.5(zod@4.3.6)
-      '@oramacloud/client':
-        specifier: ^2.1.4
-        version: 2.1.4
+      '@orama/core':
+        specifier: ^1.2.19
+        version: 1.2.19
       '@radix-ui/react-accordion':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -70,25 +70,25 @@ importers:
         version: 16.5.0
       fumadocs-core:
         specifier: ^16.2.3
-        version: 16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
+        version: 16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
       fumadocs-docgen:
         specifier: ^2.0.0
         version: 2.0.0
       fumadocs-mdx:
         specifier: 14.1.0
-        version: 14.1.0(@fumadocs/mdx-remote@1.4.4(@types/react@19.1.0)(fumadocs-core@16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(react@19.2.1))(fumadocs-core@16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
+        version: 14.1.0(@fumadocs/mdx-remote@1.4.4(@types/react@19.1.0)(fumadocs-core@16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(react@19.2.1))(fumadocs-core@16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
       fumadocs-openapi:
         specifier: 10.2.6
-        version: 10.2.6(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(fumadocs-core@16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(fumadocs-ui@16.2.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6))(prettier@3.5.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 10.2.6(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(fumadocs-core@16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(fumadocs-ui@16.2.3(@orama/core@1.2.19)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6))(prettier@3.5.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       fumadocs-twoslash:
         specifier: ^3.1.12
-        version: 3.1.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(fumadocs-ui@16.2.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.8.2)
+        version: 3.1.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(fumadocs-ui@16.2.3(@orama/core@1.2.19)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.8.2)
       fumadocs-typescript:
         specifier: ^4.0.1
         version: 4.0.1(typescript@5.8.2)
       fumadocs-ui:
         specifier: 16.2.3
-        version: 16.2.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6)
+        version: 16.2.3(@orama/core@1.2.19)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6)
       geist:
         specifier: ^1.3.1
         version: 1.3.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
@@ -1371,6 +1371,9 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
+  '@orama/core@1.2.19':
+    resolution: {integrity: sha512-AVEI0eG/a1RUQK+tBloRMppQf46Ky4kIYKEVjo0V0VfIGZHdLOE2PJR4v949kFwiTnfSJCUaxgwM74FCA1uHUA==}
+
   '@orama/cuid2@2.2.3':
     resolution: {integrity: sha512-Lcak3chblMejdlSHgYU2lS2cdOhDpU6vkfIJH4m+YKvqQyLqs1bB8+w6NT1MG5bO12NUK2GFc34Mn2xshMIQ1g==}
 
@@ -1378,12 +1381,8 @@ packages:
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
 
-  '@orama/orama@3.1.4':
-    resolution: {integrity: sha512-7tTuIdkzgRscJ7sGHVsoK9GtXSpwbfrj3WYnuSu/SepXHhshYiQaOeXc/aeLh4MfgIre6tEs/caIop8wrhMi3g==}
-    engines: {node: '>= 16.0.0'}
-
-  '@oramacloud/client@2.1.4':
-    resolution: {integrity: sha512-uNPFs4wq/iOPbggCwTkVNbIr64Vfd7ZS/h+cricXVnzXWocjDTfJ3wLL4lr0qiSu41g8z+eCAGBqJ30RO2O4AA==}
+  '@orama/oramacore-events-parser@0.0.5':
+    resolution: {integrity: sha512-yAuSwog+HQBAXgZ60TNKEwu04y81/09mpbYBCmz1RCxnr4ObNY2JnPZI7HmALbjAhLJ8t5p+wc2JHRK93ubO4w==}
 
   '@oxc-transform/binding-darwin-arm64@0.53.0':
     resolution: {integrity: sha512-QG1djnqQ+EywamRwFMRYogmbF4aL+Fmw/tDKuZ4cpWpOBPaxgTNryfYS1WwCARlZLmLzDEZr0YkYSQ7Rmjyf1Q==}
@@ -4298,9 +4297,6 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
   log-symbols@5.1.0:
     resolution: {integrity: sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==}
     engines: {node: '>=12'}
@@ -6154,10 +6150,10 @@ snapshots:
       picocolors: 1.1.1
       ts-morph: 25.0.1
 
-  '@fumadocs/mdx-remote@1.4.4(@types/react@19.1.0)(fumadocs-core@16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(react@19.2.1)':
+  '@fumadocs/mdx-remote@1.4.4(@types/react@19.1.0)(fumadocs-core@16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(react@19.2.1)':
     dependencies:
       '@mdx-js/mdx': 3.1.1
-      fumadocs-core: 16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
+      fumadocs-core: 16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
       gray-matter: 4.0.3
       react: 19.2.1
       zod: 4.3.6
@@ -6585,19 +6581,18 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
+  '@orama/core@1.2.19':
+    dependencies:
+      '@orama/cuid2': 2.2.3
+      '@orama/oramacore-events-parser': 0.0.5
+
   '@orama/cuid2@2.2.3':
     dependencies:
       '@noble/hashes': 1.7.1
 
   '@orama/orama@3.1.18': {}
 
-  '@orama/orama@3.1.4': {}
-
-  '@oramacloud/client@2.1.4':
-    dependencies:
-      '@orama/cuid2': 2.2.3
-      '@orama/orama': 3.1.4
-      lodash: 4.17.21
+  '@orama/oramacore-events-parser@0.0.5': {}
 
   '@oxc-transform/binding-darwin-arm64@0.53.0':
     optional: true
@@ -9183,7 +9178,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6):
+  fumadocs-core@16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@orama/orama': 3.1.18
@@ -9204,6 +9199,7 @@ snapshots:
       shiki: 3.21.0
       unist-util-visit: 5.0.0
     optionalDependencies:
+      '@orama/core': 1.2.19
       '@types/react': 19.1.0
       lucide-react: 0.486.0(react@19.2.1)
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -9222,14 +9218,14 @@ snapshots:
       unist-util-visit: 5.0.0
       zod: 3.24.2
 
-  fumadocs-mdx@14.1.0(@fumadocs/mdx-remote@1.4.4(@types/react@19.1.0)(fumadocs-core@16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(react@19.2.1))(fumadocs-core@16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1):
+  fumadocs-mdx@14.1.0(@fumadocs/mdx-remote@1.4.4(@types/react@19.1.0)(fumadocs-core@16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(react@19.2.1))(fumadocs-core@16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.0.0
       chokidar: 5.0.0
       esbuild: 0.27.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
+      fumadocs-core: 16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
       js-yaml: 4.1.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -9243,13 +9239,13 @@ snapshots:
       vfile: 6.0.3
       zod: 4.3.6
     optionalDependencies:
-      '@fumadocs/mdx-remote': 1.4.4(@types/react@19.1.0)(fumadocs-core@16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(react@19.2.1)
+      '@fumadocs/mdx-remote': 1.4.4(@types/react@19.1.0)(fumadocs-core@16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(react@19.2.1)
       next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-openapi@10.2.6(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(fumadocs-core@16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(fumadocs-ui@16.2.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6))(prettier@3.5.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  fumadocs-openapi@10.2.6(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(fumadocs-core@16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6))(fumadocs-ui@16.2.3(@orama/core@1.2.19)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6))(prettier@3.5.3)(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       '@fumari/json-schema-to-typescript': 2.0.0(prettier@3.5.3)
       '@fumari/stf': 0.0.1(@types/react@19.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -9261,8 +9257,8 @@ snapshots:
       '@scalar/openapi-parser': 0.23.11
       ajv: 8.17.1
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
-      fumadocs-ui: 16.2.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6)
+      fumadocs-core: 16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
+      fumadocs-ui: 16.2.3(@orama/core@1.2.19)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6)
       github-slugger: 2.0.0
       hast-util-to-jsx-runtime: 2.3.6
       js-yaml: 4.1.1
@@ -9284,11 +9280,11 @@ snapshots:
       - prettier
       - supports-color
 
-  fumadocs-twoslash@3.1.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(fumadocs-ui@16.2.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.8.2):
+  fumadocs-twoslash@3.1.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(fumadocs-ui@16.2.3(@orama/core@1.2.19)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.8.2):
     dependencies:
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@shikijs/twoslash': 3.21.0(typescript@5.8.2)
-      fumadocs-ui: 16.2.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6)
+      fumadocs-ui: 16.2.3(@orama/core@1.2.19)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6)
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
@@ -9319,7 +9315,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.2.3(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6):
+  fumadocs-ui@16.2.3(@orama/core@1.2.19)(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.1)(zod@4.3.6):
     dependencies:
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -9332,7 +9328,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.1.0)(react@19.2.1)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.1.1(@types/react@19.1.0))(@types/react@19.1.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.2.3(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
+      fumadocs-core: 16.2.3(@orama/core@1.2.19)(@types/react@19.1.0)(lucide-react@0.486.0(react@19.2.1))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@4.3.6)
       lodash.merge: 4.6.2
       next-themes: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       postcss-selector-parser: 7.1.1
@@ -9946,8 +9942,6 @@ snapshots:
   lodash-es@4.17.21: {}
 
   lodash.merge@4.6.2: {}
-
-  lodash@4.17.21: {}
 
   log-symbols@5.1.0:
     dependencies:

--- a/scripts/update-orama-ai.mts
+++ b/scripts/update-orama-ai.mts
@@ -1,5 +1,5 @@
 import * as fs from 'node:fs/promises';
-import { CloudManager } from '@oramacloud/client';
+import { OramaCloud } from '@orama/core';
 import fg from 'fast-glob';
 import matter from 'gray-matter';
 import path from 'node:path';
@@ -22,21 +22,22 @@ const processor = remark()
 
 export async function updateOramaAi(): Promise<void> {
   const apiKey = process.env.ORAMA_PRIVATE_API_KEY;
+  const projectId = process.env.NEXT_PUBLIC_ORAMA_PROJECT_ID;
   const index = process.env.ORAMA_AI_INDEX_ID;
 
-  if (!apiKey || !index) {
+  if (!apiKey || !projectId || !index) {
     console.log('no api key for Orama found, skipping');
     return;
   }
 
-  const manager = new CloudManager({ api_key: apiKey });
-  const indexManager = manager.index(index);
+  const orama = new OramaCloud({ projectId, apiKey });
+  const indexManager = orama.index.set(index);
 
   const files = await fg([
     './content/docs/**/*.mdx',
     '!./content/docs/api/reference/**/*',
   ]);
-  const records: unknown[] = [];
+  const records: Record<string, unknown>[] = [];
 
   console.log('processing documents for AI');
   const scan = files.map(async (file) => {
@@ -68,6 +69,7 @@ export async function updateOramaAi(): Promise<void> {
   await Promise.all(scan);
 
   console.log(`added ${records.length} records`);
-  await indexManager.snapshot(records);
-  await indexManager.deploy();
+  await indexManager.transaction.open();
+  await indexManager.transaction.insertDocuments(records);
+  await indexManager.transaction.commit();
 }

--- a/scripts/update-orama-ai.mts
+++ b/scripts/update-orama-ai.mts
@@ -20,6 +20,15 @@ const processor = remark()
   .use(remarkInstall, { persist: { id: 'package-manager' } })
   .use(remarkStringify);
 
+interface OramaAiRecord {
+  [key: string]: unknown;
+  id: string;
+  title: string;
+  description: string;
+  content: string;
+  category?: string;
+}
+
 export async function updateOramaAi(): Promise<void> {
   const apiKey = process.env.ORAMA_PRIVATE_API_KEY;
   const projectId = process.env.NEXT_PUBLIC_ORAMA_PROJECT_ID;
@@ -37,7 +46,7 @@ export async function updateOramaAi(): Promise<void> {
     './content/docs/**/*.mdx',
     '!./content/docs/api/reference/**/*',
   ]);
-  const records: Record<string, unknown>[] = [];
+  const records: OramaAiRecord[] = [];
 
   console.log('processing documents for AI');
   const scan = files.map(async (file) => {
@@ -61,7 +70,7 @@ export async function updateOramaAi(): Promise<void> {
       id: file,
       title: data.title as string,
       description: data.description as string,
-      content: processed,
+      content: String(processed),
       category,
     });
   });
@@ -70,6 +79,14 @@ export async function updateOramaAi(): Promise<void> {
 
   console.log(`added ${records.length} records`);
   await indexManager.transaction.open();
-  await indexManager.transaction.insertDocuments(records);
-  await indexManager.transaction.commit();
+  try {
+    await indexManager.transaction.insertDocuments(records);
+    await indexManager.transaction.commit();
+  } catch (error) {
+    console.error('transaction failed, rolling back:', error);
+    await indexManager.transaction.rollback().catch((rollbackError: unknown) => {
+      console.error('rollback failed:', rollbackError);
+    });
+    throw error;
+  }
 }

--- a/scripts/update-orama-index.mts
+++ b/scripts/update-orama-index.mts
@@ -1,23 +1,29 @@
 import { sync, type OramaDocument } from 'fumadocs-core/search/orama-cloud';
 import * as fs from 'node:fs/promises';
-import { CloudManager } from '@oramacloud/client';
+import { OramaCloud } from '@orama/core';
 
 export async function updateSearchIndexes(): Promise<void> {
   const apiKey = process.env.ORAMA_PRIVATE_API_KEY;
+  const projectId = process.env.NEXT_PUBLIC_ORAMA_PROJECT_ID;
   const index = process.env.ORAMA_SEARCH_INDEX_ID;
 
-  if (!apiKey || !index) {
+  if (!apiKey || !projectId || !index) {
     console.log('no api key for Orama found, skipping');
     return;
   }
 
   const content = await fs.readFile('.next/server/app/static.json.body');
-  const records = JSON.parse(content.toString()) as OramaDocument[];
+  const allRecords = JSON.parse(content.toString()) as OramaDocument[];
 
-  const manager = new CloudManager({ api_key: apiKey });
+  const allowedTags = new Set(['api', 'api-v2']);
+  const records = allRecords.filter((doc) => doc.tag && allowedTags.has(doc.tag));
 
-  await sync(manager, {
-    index: index,
+  console.log(`filtering: ${records.length}/${allRecords.length} documents (tags: ${[...allowedTags].join(', ')})`);
+
+  const orama = new OramaCloud({ projectId, apiKey });
+
+  await sync(orama, {
+    index,
     documents: records,
   });
 

--- a/scripts/update-orama-index.mts
+++ b/scripts/update-orama-index.mts
@@ -18,6 +18,12 @@ export async function updateSearchIndexes(): Promise<void> {
   const allowedTags = new Set(['api', 'api-v2']);
   const records = allRecords.filter((doc) => doc.tag && allowedTags.has(doc.tag));
 
+  if (records.length === 0) {
+    throw new Error(
+      `no documents matched allowed tags (${[...allowedTags].join(', ')}), aborting to prevent empty index`,
+    );
+  }
+
   console.log(`filtering: ${records.length}/${allRecords.length} documents (tags: ${[...allowedTags].join(', ')})`);
 
   const orama = new OramaCloud({ projectId, apiKey });


### PR DESCRIPTION
## Summary
- Replace `@oramacloud/client` with `@orama/core` (new SDK) to align with fumadocs v16.2.3 type expectations
- Simplify env vars: 7 vars → 5 (`NEXT_PUBLIC_ORAMA_PROJECT_ID`, `NEXT_PUBLIC_ORAMA_API_KEY`, `ORAMA_PRIVATE_API_KEY`, `ORAMA_SEARCH_INDEX_ID`, `ORAMA_AI_INDEX_ID`)
- Filter search index to `api` + `api-v2` tags only (~4901 entries, under 5000 limit)
- Update AI engine from `OramaClient.createAnswerSession()` to `OramaCloud.ai.createAISession()` with new streaming API
- Update build scripts to use `OramaCloud.index.set().transaction` API
- Update GitHub workflow env var references

## Environment variables to set in production
After merging, update these secrets/env vars:

| Variable | Scope | Description |
|---|---|---|
| `NEXT_PUBLIC_ORAMA_PROJECT_ID` | Public | `d0dd844f-8142-4391-8723-91dffd9db5a7` |
| `NEXT_PUBLIC_ORAMA_API_KEY` | Public | From Orama dashboard |
| `ORAMA_PRIVATE_API_KEY` | Secret | For build scripts (index sync) |
| `ORAMA_SEARCH_INDEX_ID` | Secret | `50e725ce-21bc-412b-bba6-6ad2799c54cc` |
| `ORAMA_AI_INDEX_ID` | Secret | AI datasource ID from dashboard |

Old vars to remove: `NEXT_PUBLIC_ORAMA_SEARCH_ENDPOINT`, `NEXT_PUBLIC_ORAMA_SEARCH_API_KEY`, `NEXT_PUBLIC_ORAMA_AI_ENDPOINT`, `NEXT_PUBLIC_ORAMA_AI_API_KEY`

## Test plan
- [x] `pnpm build` passes TypeScript compilation
- [x] Search index sync works (`121 documents → ~4901 index entries`)
- [ ] Verify search works in deployed preview
- [ ] Verify AI chat works in deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)