### PR TITLE
docs: increase silence_timeout max from 1800s to 3600s

### DIFF
--- a/content/docs/api-v2/getting-started/sending-a-bot.mdx
+++ b/content/docs/api-v2/getting-started/sending-a-bot.mdx
@@ -176,7 +176,7 @@ To schedule a bot to join at a specific time, use `POST /v2/bots/scheduled`:
 - `timeout_config`: Optional object:
   - `waiting_room_timeout`: Seconds to wait in waiting room (default: 600, min: 120, max: 1800)
   - `no_one_joined_timeout`: Seconds to wait if no one joins (default: 600, min: 120, max: 1800, isn't used by Zoom)
-  - `silence_timeout`: Once a participant has been identified, no_one_joined_timeout stops and silence_timeout kicks in. When there is continued silence for the seconds provided, the bot leaves the meeting (default: 600, min: 300, max: 1800, isn't used by Zoom)
+  - `silence_timeout`: Once a participant has been identified, no_one_joined_timeout stops and silence_timeout kicks in. When there is continued silence for the seconds provided, the bot leaves the meeting (default: 600, min: 300, max: 3600, isn't used by Zoom)
 
 ### Advanced Options
 


### PR DESCRIPTION
Updated sending-a-bot.mdx getting-started guide (max: 1800 → 3600)