### PR TITLE
fix(docs-mcp): full api-v2 indexing + OpenAPI param docs (assistant grounding)

### DIFF
--- a/lib/llms/content.ts
+++ b/lib/llms/content.ts
@@ -21,6 +21,20 @@ export const llmCategoryKeys = Object.keys(llmCategoryConfig);
  * `content/**` must be present in the runtime working directory (it is in the
  * repo and is copied into the Docker image — see Dockerfile).
  */
+// Fumadocs OpenAPI pages stash the rendered parameter/field/response docs in
+// frontmatter under `_openapi.structuredData.contents` (an array of { content }).
+// Pull that prose out as plain text so it's part of the bundle.
+function extractStructuredText(data: unknown): string {
+  const sd =
+    (data as any)?._openapi?.structuredData?.contents ??
+    (data as any)?.structuredData?.contents;
+  if (!Array.isArray(sd)) return '';
+  return sd
+    .map((c) => (typeof c === 'string' ? c : c?.content))
+    .filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+    .join('\n\n');
+}
+
 export async function getCategoryContent(categoryKey: string): Promise<string> {
   const config = llmCategoryConfig[categoryKey];
   if (!config) {
@@ -45,7 +59,16 @@ export async function getCategoryContent(categoryKey: string): Promise<string> {
       out += `## ${title}\n\n`;
       if (description) out += `${description}\n\n`;
       out += `### Source: ${filePath}\n\n`;
-      out += content;
+      // Body, minus the Fumadocs <APIPage/> component — it renders the
+      // parameter/field docs from the OpenAPI spec at build time, so it
+      // contributes no text here.
+      out += content.replace(/<APIPage[\s\S]*?\/>/g, '').trim();
+      // OpenAPI reference pages keep their actual parameter/field docs in the
+      // frontmatter's structuredData (NOT the body). Include them so
+      // field-level questions (e.g. timeout_config.grace_period) are answerable
+      // instead of the model concluding the field doesn't exist.
+      const structured = extractStructuredText(data);
+      if (structured) out += `\n\n${structured}`;
       out += '\n\n---\n\n';
     } catch (error) {
       console.error(`[llms] error processing ${filePath}:`, error);

--- a/lib/llms/mcp-server.ts
+++ b/lib/llms/mcp-server.ts
@@ -22,7 +22,9 @@ const slugFromSource = (p: string) =>
     .replace(/^\.?\/?content\/docs\//, '')
     .replace(/\.mdx$/, '')
     .replace(/\/index$/, '');
-const pageUrl = (slug: string) => `${PUBLIC_DOCS}/docs/${slug}`;
+// The public docs serve pages at the root (the site 301-redirects /docs/* → /*),
+// so cite the canonical URL without the /docs prefix.
+const pageUrl = (slug: string) => `${PUBLIC_DOCS}/${slug}`;
 
 const DOC_CATEGORIES = {
   ALL: 'all',
@@ -165,23 +167,60 @@ function matchPage(pages: DocPage[], norm: string): DocPage | undefined {
   return suffix.length === 1 ? suffix[0] : undefined;
 }
 
+// reference-section → section tool, for the hint in the index.
+const SECTION_TOOL: Record<string, string> = {
+  bots: 'getApiV2BotsDocs',
+  calendars: 'getApiV2CalendarsDocs',
+  callbacks: 'getApiV2CallbacksDocs',
+  webhooks: 'getApiV2WebhooksDocs',
+  'zoom-credentials': 'getApiV2ZoomCredentialsDocs',
+};
+
+// Build a complete index of EVERY v2 page (loaded once from the api-v2 bundle),
+// grouped into guides/concepts + each reference section — so nothing is
+// invisible to the model. Fetch any line with getDocsPage({ slug }).
 export async function buildApiIndex(): Promise<string> {
   const blocks: string[] = [
-    '# MeetingBaas API v2 — Index',
-    'Use a section tool for full detail, or getDocsPage({ slug }) for one endpoint.',
+    '# MeetingBaas API v2 — Index (all pages)',
+    'Fetch any page with getDocsPage({ slug }), or a whole section with getDocsByCategory({ category }).',
     '',
   ];
-  for (const s of V2_SECTIONS) {
-    blocks.push(`## ${s.label} — \`${s.tool}\``);
-    try {
-      for (const p of await pagesFor(s.cat)) {
-        blocks.push(`- ${p.title} — ${p.url}  \`slug: ${p.slug}\``);
-      }
-    } catch {
-      blocks.push(`- (index unavailable; call \`${s.tool}\`)`);
-    }
-    blocks.push('');
+
+  let pages: DocPage[];
+  try {
+    pages = await pagesFor(DOC_CATEGORIES.API_V2);
+  } catch {
+    blocks.push('(index unavailable; call getApiV2FullDocs)');
+    return blocks.join('\n');
   }
+
+  // Group by section: api-v2/reference/<section>/… → <section>; everything else
+  // (getting-started, batch-operations, streaming, …) → guides.
+  const groups = new Map<string, DocPage[]>();
+  for (const p of pages) {
+    const m = p.slug.match(/^api-v2\/reference\/([^/]+)/);
+    const key = m ? m[1] : 'guides';
+    (groups.get(key) ?? groups.set(key, []).get(key)!).push(p);
+  }
+
+  const emit = (heading: string, list: DocPage[]) => {
+    if (!list.length) return;
+    blocks.push(`## ${heading}`);
+    for (const p of list) blocks.push(`- ${p.title} — ${p.url}  \`slug: ${p.slug}\``);
+    blocks.push('');
+  };
+
+  // Guides first (how-to / conceptual), then reference sections (known order, then any others).
+  emit('Guides & Concepts — fetch with `getDocsPage({ slug })`', groups.get('guides') ?? []);
+  groups.delete('guides');
+
+  const known = Object.keys(SECTION_TOOL).filter((k) => groups.has(k));
+  const rest = [...groups.keys()].filter((k) => !(k in SECTION_TOOL)).sort();
+  for (const sec of [...known, ...rest]) {
+    const tool = SECTION_TOOL[sec];
+    emit(`${sec} (reference)${tool ? ` — \`${tool}\`` : ''}`, groups.get(sec) ?? []);
+  }
+
   return blocks.join('\n');
 }
 


### PR DESCRIPTION
## Problem

The docs AI assistant confidently said API fields **don't exist** when they do — e.g. it claimed `createBot` has no grace-period option and even "cited" the source as proof. (Reported in #general: the `timeout_config.grace_period` field.)

## Root cause

Fumadocs **OpenAPI reference pages** render their parameter/field/response docs from the spec at build time. The MDX **body** is only a prose intro + an `<APIPage … />` component — the actual field docs live in the **frontmatter** under `_openapi.structuredData.contents`.

`getCategoryContent` emitted only `title` + `description` + body, so it stripped exactly the frontmatter where every parameter lives. `getDocsPage(createBot)` returned ~1,930 chars of intro with **zero parameters**, so the model correctly concluded (from empty input) that the field wasn't there. This affected **every** API-reference field, not just grace period.

## Fix

`lib/llms/content.ts` now extracts `_openapi.structuredData.contents` into the bundle (and drops the inert `<APIPage/>` tag).

## Verification (via `/mcp`)
- `getDocsPage(api-v2/reference/bots/createBot)`: **1,930 → ~9,900 chars**, now contains `timeout_config.grace_period: The grace period in seconds at the start of the meeting …` (default 0, max 600).
- `getDocsByCategory(api-v2/bots)`: also includes it.
- Production build compiles + typechecks.

Follow-up to #132 (the field-content gap surfaced after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
### Also: index *every* api-v2 page + canonical links
`getApiDocs` only listed five hardcoded reference sections, so getting-started **guides** (Google Meet setup, sending **authenticated / "logged-in" bots**, batch operations, streaming…) and reference sections like `meet-logins`/`meet-workspaces` were **invisible** — the assistant concluded Google Meet / logged-in bots weren't supported. The index is now built from the full api-v2 bundle, grouping **every** page into *Guides & Concepts* + each reference section. Citations now use canonical URLs (site 301s `/docs/*` → `/*`).

Verified via `/mcp`: index lists `meet/setup`, `sending-authenticated-bots`, `batch-operations`, and the `meet-logins`/`meet-workspaces` sections; links are `https://docs.meetingbaas.com/api-v2/...`.