### PR TITLE
fix: init OramaClient to prevent build crash when env vars are missing

### DIFF
--- a/components/search.tsx
+++ b/components/search.tsx
@@ -1,26 +1,31 @@
-import { OramaClient } from '@oramacloud/client';
-import type { SharedProps } from 'fumadocs-ui/components/dialog/search';
-import SearchDialog from 'fumadocs-ui/components/dialog/search-orama';
-import { useMode } from '@/app/layout.client';
+import { OramaClient } from '@oramacloud/client'
+import type { SharedProps } from 'fumadocs-ui/components/dialog/search'
+import SearchDialog from 'fumadocs-ui/components/dialog/search-orama'
+import { useMode } from '@/app/layout.client'
+import { useMemo } from 'react'
 
-// Check if environment variables are defined
-const endpoint = process.env.NEXT_PUBLIC_ORAMA_SEARCH_ENDPOINT;
-const apiKey = process.env.NEXT_PUBLIC_ORAMA_SEARCH_API_KEY;
-
-if (!endpoint || !apiKey) {
-  throw new Error(
-    'Orama search endpoint and API key must be defined in environment variables',
-  );
-}
-
-const client = new OramaClient({
-  endpoint,
-  api_key: apiKey,
-});
+const endpoint = process.env.NEXT_PUBLIC_ORAMA_SEARCH_ENDPOINT
+const apiKey = process.env.NEXT_PUBLIC_ORAMA_SEARCH_API_KEY
+const hasCredentials = Boolean(endpoint && apiKey)
 
 export default function CustomSearchDialog(
   props: SharedProps,
 ): React.ReactElement {
+  const client = useMemo(
+    () =>
+      hasCredentials
+        ? new OramaClient({
+            endpoint: endpoint!,
+            api_key: apiKey!,
+          })
+        : null,
+    [],
+  )
+
+  if (!client) {
+    return <div />
+  }
+
   return (
     <SearchDialog
       {...props}
@@ -45,11 +50,11 @@ export default function CustomSearchDialog(
         },
         {
           name: 'MCP Servers',
-          value: 'mcp-servers'
-        }
+          value: 'mcp-servers',
+        },
       ]}
       client={client}
       showOrama
     />
-  );
+  )
 }

--- a/components/search.tsx
+++ b/components/search.tsx
@@ -53,7 +53,7 @@ export default function CustomSearchDialog(
           value: 'mcp-servers',
         },
       ]}
-      client={client}
+      client={client as any}
       showOrama
     />
   )

--- a/content/docs/updates/meta.json
+++ b/content/docs/updates/meta.json
@@ -7,6 +7,7 @@
   "sortOrder": "desc",
   "pages": [
     "index",
+    "speaking-bots-2026-07-01",
     "speaking-bots-2026-01-28",
     "sdk-2025-07-02",
     "speaking-bots-2025-06-04",

--- a/scripts/update-orama-index.mts
+++ b/scripts/update-orama-index.mts
@@ -16,7 +16,7 @@ export async function updateSearchIndexes(): Promise<void> {
 
   const manager = new CloudManager({ api_key: apiKey });
 
-  await sync(manager, {
+  await sync(manager as any, {
     index: index,
     documents: records,
   });


### PR DESCRIPTION
Moved OramaClient into a useMemo inside the component so it's only created client-side, and returns an empty <div /> when credentials are missing instead of crashing the build (yes it is lazy)