### PR TITLE
docs(webhooks): document bot.status_change codes incl. pickup_delayed

### DIFF
--- a/content/docs/api-v2/webhooks.mdx
+++ b/content/docs/api-v2/webhooks.mdx
@@ -92,6 +92,16 @@ Failure:
 - `recording_failed`: Recording failed
 - `transcription_failed`: Recording succeeded but transcription failed
 
+Intermediate errors (informational; these precede `recording_failed`):
+
+- `api_request_stop`: Bot was stopped via the API
+- `bot_rejected`: Bot was rejected from the meeting
+- `bot_removed`: Bot was removed from the meeting
+- `bot_removed_too_early`: Bot was removed before recording could complete
+- `waiting_room_timeout`: Bot timed out waiting to be admitted from the waiting room
+- `invalid_meeting_url`: The meeting URL was invalid
+- `meeting_error`: A general meeting error occurred
+
 <Callout type="info">
   **`pickup_delayed`** is emitted when a bot remains in `queued` longer than the pickup threshold (**default 5 minutes**, configurable). It is a **transient** status: if a worker later picks the bot up, the normal flow resumes (`pickup_delayed → joining_call → ...`). Use it to detect a slow start early and take action — for example, stop the bot via `POST /v2/bots/{bot_id}/leave` and re-create it.
 </Callout>
@@ -167,6 +177,13 @@ Triggered when a bot fails to complete successfully.
 - `DAILY_BOT_CAP_REACHED`: Daily bot creation limit reached
 - `INVALID_MEETING_PLATFORM`: Could not determine meeting platform from URL
 - `TRANSCRIPTION_ERROR`: Error occurred during transcription
+
+Google Meet authenticated (SSO) bots:
+
+- `MEET_LOGIN_UNAVAILABLE`: No authenticated Meet login was available when the bot was dispatched
+- `MEET_LOGIN_REQUIRED`: The meeting requires sign-in but the bot was dispatched without an authenticated login
+- `MEET_LOGIN_FAILED_SAML_REJECTED`: Google rejected the SSO sign-in (commonly a certificate mismatch in your Workspace SSO configuration)
+- `MEET_LOGIN_FAILED_TIMEOUT`: The bot's SSO sign-in with Google timed out (usually transient; the bot retries)
 
 ## Calendar Webhooks
 

--- a/content/docs/api-v2/webhooks.mdx
+++ b/content/docs/api-v2/webhooks.mdx
@@ -39,7 +39,7 @@ To verify webhooks, use SVIX's verification libraries or verify the signature ma
 
 ### `bot.status_change`
 
-Triggered whenever a bot's status changes (e.g., from `queued` to `joining`, from `joining` to `in_call_recording`, etc.).
+Triggered whenever a bot's status changes (e.g., from `queued` to `joining_call`, from `joining_call` to `in_call_recording`, etc.).
 
 **Use Cases:**
 
@@ -70,12 +70,31 @@ Triggered whenever a bot's status changes (e.g., from `queued` to `joining`, fro
 
 **Status Codes:**
 
-- `queued`: Bot is queued and waiting to join
-- `joining`: Bot is attempting to join the meeting
+Lifecycle:
+
+- `queued`: Bot is queued and waiting to be picked up
+- `pickup_delayed`: Bot has stayed queued past the pickup threshold (see below)
+- `joining_call`: Bot is attempting to join the meeting
+- `in_waiting_room`: Bot is in the meeting's waiting room
+- `in_waiting_for_host`: Bot is waiting for the host to start the meeting
+- `in_call_not_recording`: Bot is in the call but not recording yet
 - `in_call_recording`: Bot is in the meeting and recording
+- `recording_paused`: Recording was paused
+- `recording_resumed`: Recording resumed after a pause
+- `call_ended`: The call ended
+- `recording_succeeded`: Recording completed successfully
 - `transcribing`: Bot has exited and transcription is in progress
 - `completed`: Bot has completed successfully
-- `failed`: Bot has failed
+
+Failure:
+
+- `failed`: Bot failed
+- `recording_failed`: Recording failed
+- `transcription_failed`: Recording succeeded but transcription failed
+
+<Callout type="info">
+  **`pickup_delayed`** is emitted when a bot remains in `queued` longer than the pickup threshold (**default 5 minutes**, configurable). It is a **transient** status: if a worker later picks the bot up, the normal flow resumes (`pickup_delayed → joining_call → ...`). Use it to detect a slow start early and take action — for example, stop the bot via `POST /v2/bots/{bot_id}/leave` and re-create it.
+</Callout>
 
 ### `bot.completed`
 

--- a/content/llm/api-v2.md
+++ b/content/llm/api-v2.md
@@ -5604,6 +5604,16 @@ Failure:
 - `recording_failed`: Recording failed
 - `transcription_failed`: Recording succeeded but transcription failed
 
+Intermediate errors (informational; these precede `recording_failed`):
+
+- `api_request_stop`: Bot was stopped via the API
+- `bot_rejected`: Bot was rejected from the meeting
+- `bot_removed`: Bot was removed from the meeting
+- `bot_removed_too_early`: Bot was removed before recording could complete
+- `waiting_room_timeout`: Bot timed out waiting to be admitted from the waiting room
+- `invalid_meeting_url`: The meeting URL was invalid
+- `meeting_error`: A general meeting error occurred
+
 <Callout type="info">
   **`pickup_delayed`** is emitted when a bot remains in `queued` longer than the pickup threshold (**default 5 minutes**, configurable). It is a **transient** status: if a worker later picks the bot up, the normal flow resumes (`pickup_delayed → joining_call → ...`). Use it to detect a slow start early and take action — for example, stop the bot via `POST /v2/bots/{bot_id}/leave` and re-create it.
 </Callout>
@@ -5679,6 +5689,13 @@ Triggered when a bot fails to complete successfully.
 - `DAILY_BOT_CAP_REACHED`: Daily bot creation limit reached
 - `INVALID_MEETING_PLATFORM`: Could not determine meeting platform from URL
 - `TRANSCRIPTION_ERROR`: Error occurred during transcription
+
+Google Meet authenticated (SSO) bots:
+
+- `MEET_LOGIN_UNAVAILABLE`: No authenticated Meet login was available when the bot was dispatched
+- `MEET_LOGIN_REQUIRED`: The meeting requires sign-in but the bot was dispatched without an authenticated login
+- `MEET_LOGIN_FAILED_SAML_REJECTED`: Google rejected the SSO sign-in (commonly a certificate mismatch in your Workspace SSO configuration)
+- `MEET_LOGIN_FAILED_TIMEOUT`: The bot's SSO sign-in with Google timed out (usually transient; the bot retries)
 
 ## Calendar Webhooks
 

--- a/content/llm/api-v2.md
+++ b/content/llm/api-v2.md
@@ -2085,7 +2085,7 @@ To schedule a bot to join at a specific time, use `POST /v2/bots/scheduled`:
 - `timeout_config`: Optional object:
   - `waiting_room_timeout`: Seconds to wait in waiting room (default: 600, min: 120, max: 1800)
   - `no_one_joined_timeout`: Seconds to wait if no one joins (default: 600, min: 120, max: 1800, isn't used by Zoom)
-  - `silence_timeout`: Once a participant has been identified, no_one_joined_timeout stops and silence_timeout kicks in. When there is continued silence for the seconds provided, the bot leaves the meeting (default: 600, min: 300, max: 1800, isn't used by Zoom)
+  - `silence_timeout`: Once a participant has been identified, no_one_joined_timeout stops and silence_timeout kicks in. When there is continued silence for the seconds provided, the bot leaves the meeting (default: 600, min: 300, max: 3600, isn't used by Zoom)
 
 ### Advanced Options
 
@@ -3715,7 +3715,7 @@ Retry sending the transcription callback for a bot.
     
     **Idempotency:** This operation is idempotent. You can call it multiple times with the same or different configurations.
     
-    Returns 404 if the bot is not found, or 409 if the bot's status does not allow this operation or if no callback was configured.
+    Returns 404 if the bot is not found, 400 if no callback is configured for the bot, or 409 if the bot's status does not allow this operation.
 
 <APIPage document={"./openapi-v2.json"} operations={[{"path":"/v2/bots/{bot_id}/retry-callback","method":"post"}]} />
 
@@ -5551,7 +5551,7 @@ To verify webhooks, use SVIX's verification libraries or verify the signature ma
 
 ### `bot.status_change`
 
-Triggered whenever a bot's status changes (e.g., from `queued` to `joining`, from `joining` to `in_call_recording`, etc.).
+Triggered whenever a bot's status changes (e.g., from `queued` to `joining_call`, from `joining_call` to `in_call_recording`, etc.).
 
 **Use Cases:**
 
@@ -5582,12 +5582,31 @@ Triggered whenever a bot's status changes (e.g., from `queued` to `joining`, fro
 
 **Status Codes:**
 
-- `queued`: Bot is queued and waiting to join
-- `joining`: Bot is attempting to join the meeting
+Lifecycle:
+
+- `queued`: Bot is queued and waiting to be picked up
+- `pickup_delayed`: Bot has stayed queued past the pickup threshold (see below)
+- `joining_call`: Bot is attempting to join the meeting
+- `in_waiting_room`: Bot is in the meeting's waiting room
+- `in_waiting_for_host`: Bot is waiting for the host to start the meeting
+- `in_call_not_recording`: Bot is in the call but not recording yet
 - `in_call_recording`: Bot is in the meeting and recording
+- `recording_paused`: Recording was paused
+- `recording_resumed`: Recording resumed after a pause
+- `call_ended`: The call ended
+- `recording_succeeded`: Recording completed successfully
 - `transcribing`: Bot has exited and transcription is in progress
 - `completed`: Bot has completed successfully
-- `failed`: Bot has failed
+
+Failure:
+
+- `failed`: Bot failed
+- `recording_failed`: Recording failed
+- `transcription_failed`: Recording succeeded but transcription failed
+
+<Callout type="info">
+  **`pickup_delayed`** is emitted when a bot remains in `queued` longer than the pickup threshold (**default 5 minutes**, configurable). It is a **transient** status: if a worker later picks the bot up, the normal flow resumes (`pickup_delayed → joining_call → ...`). Use it to detect a slow start early and take action — for example, stop the bot via `POST /v2/bots/{bot_id}/leave` and re-create it.
+</Callout>
 
 ### `bot.completed`
 


### PR DESCRIPTION
## What

Documents the `bot.status_change` webhook status codes in `content/docs/api-v2/webhooks.mdx`, including the new **`pickup_delayed`** code.

`pickup_delayed` fires when a bot stays `queued` past the pickup threshold (**default 5 min, configurable**). It is **transient** — if a worker later picks the bot up, normal flow resumes. Clients can use it to detect a slow start early and react (e.g. stop the bot via `POST /v2/bots/{bot_id}/leave` and re-create it).

## Changes

- Expanded the status code list to match the backend lifecycle/failure codes (fixed `joining` → `joining_call`, added waiting-room / recording states)
- Added a `Callout` explaining `pickup_delayed`
- Regenerated `content/llm/api-v2.md` mirror

Branch cut from `preview`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)