### PR TITLE
fix(docs): realtime transcription streams over WebSocket, not HTTP POST

### DIFF
--- a/content/docs/api-v2/getting-started/sending-a-bot.mdx
+++ b/content/docs/api-v2/getting-started/sending-a-bot.mdx
@@ -176,11 +176,12 @@ To schedule a bot to join at a specific time, use `POST /v2/bots/scheduled`:
 - `timeout_config`: Optional object:
   - `waiting_room_timeout`: Seconds to wait in waiting room (default: 600, min: 120, max: 1800)
   - `no_one_joined_timeout`: Seconds to wait if no one joins (default: 600, min: 120, max: 1800, isn't used by Zoom)
-  - `silence_timeout`: Once a participant has been identified, no_one_joined_timeout stops and silence_timeout kicks in. When there is continued silence for the seconds provided, the bot leaves the meeting (default: 600, min: 300, max: 1800, isn't used by Zoom)
+  - `silence_timeout`: Once a participant has been identified, no_one_joined_timeout stops and silence_timeout kicks in. When there is continued silence for the seconds provided, the bot leaves the meeting (default: 600, min: 300, max: 3600, isn't used by Zoom)
 
 ### Advanced Options
 
 - `allow_multiple_bots`: `true` (default) to allow multiple bots in the same meeting, `false` to prevent duplicates
+- `ignored_participant_names`: Optional list of participant names to ignore when evaluating auto-leave conditions. Useful when multiple bots may join the same meeting (e.g., sandbox and staging bots) - each bot can then correctly detect when human participants have left instead of staying because it sees the other bot
 - `entry_message`: Optional message the bot sends when joining
 - `extra`: Optional custom metadata (included in webhooks and callbacks)
 - `streaming_enabled`: Enable audio streaming

--- a/content/docs/api-v2/reference/bots/createBot.mdx
+++ b/content/docs/api-v2/reference/bots/createBot.mdx
@@ -90,6 +90,20 @@ _openapi:
           Useful for storing custom metadata, tracking information, or any other
           data you need to correlate with the bot.
       - content: >-
+          ignored_participant_names: Participant names to ignore when evaluating
+          auto-leave conditions.
+
+
+          The bot will not count participants matching these names when
+          determining whether to leave a meeting. This is useful when multiple
+          bots may join the same meeting across different environments (e.g.,
+          sandbox, staging).
+
+
+          By ignoring other bots' participant names, each bot can correctly
+          detect when human participants have left and leave the meeting rather
+          than remaining indefinitely.
+      - content: >-
           meet_config: Meet-only configuration for authenticated bots via SAML
           SSO.
 
@@ -177,7 +191,7 @@ _openapi:
 
           Minimum: 5 minutes
 
-          Maximum: 30 minutes
+          Maximum: 60 minutes
       - content: >-
           timeout_config.waiting_room_timeout: The timeout in seconds for the
           bot to wait in the waiting room before leaving the meeting.

--- a/content/docs/api-v2/reference/bots/createScheduledBot.mdx
+++ b/content/docs/api-v2/reference/bots/createScheduledBot.mdx
@@ -89,6 +89,20 @@ _openapi:
           Useful for storing custom metadata, tracking information, or any other
           data you need to correlate with the bot.
       - content: >-
+          ignored_participant_names: Participant names to ignore when evaluating
+          auto-leave conditions.
+
+
+          The bot will not count participants matching these names when
+          determining whether to leave a meeting. This is useful when multiple
+          bots may join the same meeting across different environments (e.g.,
+          sandbox, staging).
+
+
+          By ignoring other bots' participant names, each bot can correctly
+          detect when human participants have left and leave the meeting rather
+          than remaining indefinitely.
+      - content: >-
           meet_config: Meet-only configuration for authenticated bots via SAML
           SSO.
 
@@ -176,7 +190,7 @@ _openapi:
 
           Minimum: 5 minutes
 
-          Maximum: 30 minutes
+          Maximum: 60 minutes
       - content: >-
           timeout_config.waiting_room_timeout: The timeout in seconds for the
           bot to wait in the waiting room before leaving the meeting.

--- a/content/docs/api-v2/reference/bots/getBotDetails.mdx
+++ b/content/docs/api-v2/reference/bots/getBotDetails.mdx
@@ -29,6 +29,9 @@ _openapi:
       - content: 'data.bot_id: The UUID of the bot'
       - content: 'data.bot_name: The name of the bot'
       - content: >-
+          data.callback_config: Callback configuration (null if callback is
+          disabled)
+      - content: >-
           data.chat_messages: Signed URL to the chat messages JSON file (valid
           for 4 hours, null if not available)
       - content: 'data.created_at: ISO 8601 timestamp when the bot was created'

--- a/content/docs/api-v2/reference/bots/updateScheduledBot.mdx
+++ b/content/docs/api-v2/reference/bots/updateScheduledBot.mdx
@@ -91,6 +91,20 @@ _openapi:
           Useful for storing custom metadata, tracking information, or any other
           data you need to correlate with the bot.
       - content: >-
+          ignored_participant_names: Participant names to ignore when evaluating
+          auto-leave conditions.
+
+
+          The bot will not count participants matching these names when
+          determining whether to leave a meeting. This is useful when multiple
+          bots may join the same meeting across different environments (e.g.,
+          sandbox, staging).
+
+
+          By ignoring other bots' participant names, each bot can correctly
+          detect when human participants have left and leave the meeting rather
+          than remaining indefinitely.
+      - content: >-
           join_at: Update the scheduled join time.
 
 
@@ -187,7 +201,7 @@ _openapi:
 
           Minimum: 5 minutes
 
-          Maximum: 30 minutes
+          Maximum: 60 minutes
       - content: >-
           timeout_config.waiting_room_timeout: The timeout in seconds for the
           bot to wait in the waiting room before leaving the meeting.

--- a/content/docs/api-v2/reference/calendars/createCalendarBot.mdx
+++ b/content/docs/api-v2/reference/calendars/createCalendarBot.mdx
@@ -79,6 +79,20 @@ _openapi:
           Useful for storing custom metadata, tracking information, or any other
           data you need to correlate with the bot.
       - content: >-
+          ignored_participant_names: Participant names to ignore when evaluating
+          auto-leave conditions.
+
+
+          The bot will not count participants matching these names when
+          determining whether to leave a meeting. This is useful when multiple
+          bots may join the same meeting across different environments (e.g.,
+          sandbox, staging).
+
+
+          By ignoring other bots' participant names, each bot can correctly
+          detect when human participants have left and leave the meeting rather
+          than remaining indefinitely.
+      - content: >-
           meet_config: Meet-only configuration for authenticated bots via SAML
           SSO.
 
@@ -156,7 +170,7 @@ _openapi:
 
           Minimum: 5 minutes
 
-          Maximum: 30 minutes
+          Maximum: 60 minutes
       - content: >-
           timeout_config.waiting_room_timeout: The timeout in seconds for the
           bot to wait in the waiting room before leaving the meeting.

--- a/content/docs/api-v2/reference/calendars/updateCalendarBot.mdx
+++ b/content/docs/api-v2/reference/calendars/updateCalendarBot.mdx
@@ -137,6 +137,20 @@ _openapi:
           Useful for storing custom metadata, tracking information, or any other
           data you need to correlate with the bot.
       - content: >-
+          ignored_participant_names: Participant names to ignore when evaluating
+          auto-leave conditions.
+
+
+          The bot will not count participants matching these names when
+          determining whether to leave a meeting. This is useful when multiple
+          bots may join the same meeting across different environments (e.g.,
+          sandbox, staging).
+
+
+          By ignoring other bots' participant names, each bot can correctly
+          detect when human participants have left and leave the meeting rather
+          than remaining indefinitely.
+      - content: >-
           meet_config: Meet-only configuration for authenticated bots via SAML
           SSO.
 
@@ -192,12 +206,14 @@ _openapi:
       - content: >-
           streaming_config.mode: The streaming mode. 'audio' (default) streams
           raw audio to output_url via WebSocket. 'transcription' runs real-time
-          speech-to-text and POSTs transcript events to output_url via HTTP
-          webhooks.
+          speech-to-text and sends transcript events to output_url over a
+          WebSocket connection, as JSON messages with event
+          'transcript.segment'.
       - content: >-
           streaming_config.output_url: When mode is 'audio': WebSocket URL where
-          the bot sends raw audio. When mode is 'transcription': HTTP URL where
-          transcript events are POSTed.
+          the bot sends raw audio. When mode is 'transcription': WebSocket URL
+          where the bot sends transcript events as JSON messages with event
+          'transcript.segment'.
       - content: >-
           streaming_config.transcription: Transcription provider configuration
           for real-time streaming STT. Required when mode is 'transcription'.
@@ -261,7 +277,7 @@ _openapi:
 
           Minimum: 5 minutes
 
-          Maximum: 30 minutes
+          Maximum: 60 minutes
       - content: >-
           timeout_config.waiting_room_timeout: The timeout in seconds for the
           bot to wait in the waiting room before leaving the meeting.

--- a/content/docs/api-v2/reference/meet-logins/createMeetLogin.mdx
+++ b/content/docs/api-v2/reference/meet-logins/createMeetLogin.mdx
@@ -21,7 +21,7 @@ _openapi:
 
               **Per-team Uniqueness on Email:** Each `email` may exist at most once per team. Attempting to register the same email twice returns 409.
 
-              **Concurrency:** Each login supports up to 20 concurrent SSO sessions. When a login hits its capacity, the round-robin assigner skips it and tries the next one in the pool. If all logins in a pool are saturated, the bot creation fails with `MEET_LOGIN_UNAVAILABLE` (or falls back to anonymous, depending on your `fallback` setting).
+              **Concurrency:** Each login supports up to 20 concurrent SSO sessions by default. When a login hits its capacity, the round-robin assigner skips it and tries the next one in the pool. If all logins in a pool are saturated, the bot creation fails with `MEET_LOGIN_UNAVAILABLE` (or falls back to anonymous, depending on your `fallback` setting).
 
               **Error Scenarios:**
               - `404 Not Found`: `workspace_id` is unknown or does not belong to your team.
@@ -112,7 +112,7 @@ Create a meet login — a Google Workspace user identity attached to a parent me
 
     **Per-team Uniqueness on Email:** Each `email` may exist at most once per team. Attempting to register the same email twice returns 409.
 
-    **Concurrency:** Each login supports up to 20 concurrent SSO sessions. When a login hits its capacity, the round-robin assigner skips it and tries the next one in the pool. If all logins in a pool are saturated, the bot creation fails with `MEET_LOGIN_UNAVAILABLE` (or falls back to anonymous, depending on your `fallback` setting).
+    **Concurrency:** Each login supports up to 20 concurrent SSO sessions by default. When a login hits its capacity, the round-robin assigner skips it and tries the next one in the pool. If all logins in a pool are saturated, the bot creation fails with `MEET_LOGIN_UNAVAILABLE` (or falls back to anonymous, depending on your `fallback` setting).
 
     **Error Scenarios:**
     - `404 Not Found`: `workspace_id` is unknown or does not belong to your team.

--- a/content/docs/api-v2/streaming.mdx
+++ b/content/docs/api-v2/streaming.mdx
@@ -13,7 +13,7 @@ Streaming provides:
 - **Output Streaming**: Receive the meeting's mixed audio in real time via WebSocket
 - **Input Streaming**: Send audio into the meeting so participants can hear it (for speaking bots, AI agents, etc.)
 - **Bidirectional Streaming**: Combine both - receive meeting audio and speak back - using a single or two separate WebSocket connections
-- **Managed Real-Time Transcription**: Let Meeting BaaS run real-time speech-to-text and POST transcript events to your endpoint, with a choice of providers
+- **Managed Real-Time Transcription**: Let Meeting BaaS run real-time speech-to-text and stream transcript events to your WebSocket endpoint, with a choice of providers
 - **Speaker Diarization**: Receive real-time speaker state updates as JSON messages alongside the audio stream
 - **Configurable Sample Rate**: Choose from 16,000 Hz, 24,000 Hz (default), 32,000 Hz, or 48,000 Hz
 - **Works on All Platforms**: Google Meet, Microsoft Teams, and Zoom
@@ -39,8 +39,8 @@ To enable streaming, include `streaming_enabled` and `streaming_config` in your 
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `mode` | `string` | `audio` | Streaming mode. `audio` streams raw audio over WebSocket; `transcription` runs managed real-time speech-to-text and POSTs transcript events to `output_url` |
-| `output_url` | `string \| null` | `null` | When `mode` is `audio`: WebSocket URL where the bot sends meeting audio. When `mode` is `transcription`: HTTP(S) URL where transcript events are POSTed |
+| `mode` | `string` | `audio` | Streaming mode. `audio` streams raw audio over WebSocket; `transcription` runs managed real-time speech-to-text and streams JSON transcript events to `output_url` over WebSocket |
+| `output_url` | `string \| null` | `null` | When `mode` is `audio`: WebSocket URL where the bot sends meeting audio. When `mode` is `transcription`: WebSocket URL where the bot sends transcript events as JSON messages |
 | `input_url` | `string \| null` | `null` | WebSocket URL from which the bot receives audio to play into the meeting |
 | `audio_frequency` | `integer` | `24000` | Sample rate in Hz. Supported: `16000`, `24000`, `32000`, `48000` |
 | `transcription` | `object \| null` | `null` | Real-time STT provider configuration. Required when `mode` is `transcription` (see [Managed Real-Time Transcription](#managed-real-time-transcription)) |
@@ -124,14 +124,14 @@ When the URLs differ, the bot opens two separate WebSocket connections - one for
 
 ### Managed Real-Time Transcription
 
-Set `mode` to `"transcription"` to have Meeting BaaS run real-time speech-to-text for you and **POST transcript events to your `output_url` over HTTP(S)** as the meeting happens - no need to run your own STT engine on the audio stream.
+Set `mode` to `"transcription"` to have Meeting BaaS run real-time speech-to-text for you and **stream transcript events to your `output_url` over WebSocket** as the meeting happens - no need to run your own STT engine on the audio stream.
 
 ```json
 {
   "streaming_enabled": true,
   "streaming_config": {
     "mode": "transcription",
-    "output_url": "https://your-server.com/transcripts",
+    "output_url": "wss://your-server.com/transcripts",
     "transcription": {
       "provider": "gladia",
       "api_key": null,
@@ -152,8 +152,46 @@ The `streaming_config.transcription` object configures the real-time STT provide
 | `region` | `string \| null` | `null` | Provider API region. When omitted, provider defaults apply (`gladia=eu-west`, `deepgram=eu`, `assemblyai=eu`, `speechmatics=eu1`, `soniox=us`, `elevenlabs=global`) |
 
 <Callout type="info">
-  All [batch transcription providers](/docs/api-v2/transcription#transcription-providers) are available for real-time streaming, plus **ElevenLabs**, which is streaming-only. When `mode` is `transcription`, `output_url` is treated as an HTTP(S) webhook endpoint rather than a WebSocket.
+  All [batch transcription providers](/docs/api-v2/transcription#transcription-providers) are available for real-time streaming, plus **ElevenLabs**, which is streaming-only. In `transcription` mode, `output_url` is still a **WebSocket** endpoint (`wss://`) - the bot opens a WebSocket connection to it and sends JSON text messages. It does not send HTTP POST requests.
 </Callout>
+
+#### Transcript Events
+
+Your WebSocket server receives JSON text messages, one per transcript segment. Every message has the same envelope:
+
+```json
+{
+  "event": "transcript.segment",
+  "bot_id": "123e4567-e89b-12d3-a456-426614174000",
+  "data": {
+    "text": "Hello everyone, let's get started.",
+    "isFinal": true,
+    "utteranceStart": 12.34,
+    "utteranceEnd": 15.02,
+    "confidence": 0.97,
+    "words": [
+      { "text": "Hello", "start": 12.34, "end": 12.61, "confidence": 0.98 }
+    ],
+    "speaker": { "name": "John Doe", "id": 1 }
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event` | `string` | Always `"transcript.segment"` - the only event type sent in transcription mode |
+| `bot_id` | `string` | UUID of the bot |
+| `data.text` | `string` | Transcribed text for this segment |
+| `data.isFinal` | `boolean` | `false` for partial (interim) segments, `true` for final segments. Partial segments may be revised by a later message covering the same utterance |
+| `data.utteranceStart` | `number` | Utterance start time in seconds |
+| `data.utteranceEnd` | `number` | Utterance end time in seconds |
+| `data.confidence` | `number` | Overall confidence score for the segment (0-1), when the provider reports one |
+| `data.words` | `array` | Word-level timings: `{ text, start, end, confidence?, speaker? }` |
+| `data.speaker` | `object \| null` | Active speaker at the time of the segment: `{ name, id }`, or `null` when unknown |
+
+Fields other than `event` may be absent depending on the STT provider - treat them as optional.
+
+If the WebSocket connection drops, the bot reconnects with exponential backoff (1s doubling up to 60s) and buffers up to 100 transcript events while disconnected, flushing them on reconnect. Events beyond the buffer limit are dropped.
 
 ## WebSocket Protocol
 

--- a/content/docs/api-v2/streaming.mdx
+++ b/content/docs/api-v2/streaming.mdx
@@ -40,13 +40,13 @@ To enable streaming, include `streaming_enabled` and `streaming_config` in your 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `mode` | `string` | `audio` | Streaming mode. `audio` streams raw audio over WebSocket; `transcription` runs managed real-time speech-to-text and streams JSON transcript events to `output_url` over WebSocket |
-| `output_url` | `string \| null` | `null` | When `mode` is `audio`: WebSocket URL where the bot sends meeting audio. When `mode` is `transcription`: WebSocket URL where the bot sends transcript events as JSON messages |
+| `output_url` | `string \| null` | `null` | When `mode` is `audio`: WebSocket URL where the bot sends meeting audio (optional). When `mode` is `transcription`: WebSocket URL where the bot sends transcript events as JSON messages - **required and non-null** in this mode |
 | `input_url` | `string \| null` | `null` | WebSocket URL from which the bot receives audio to play into the meeting |
 | `audio_frequency` | `integer` | `24000` | Sample rate in Hz. Supported: `16000`, `24000`, `32000`, `48000` |
 | `transcription` | `object \| null` | `null` | Real-time STT provider configuration. Required when `mode` is `transcription` (see [Managed Real-Time Transcription](#managed-real-time-transcription)) |
 
 <Callout type="info">
-  Provide `output_url` to receive meeting audio, `input_url` to send audio into the meeting, or both for bidirectional streaming. Set either to `null` if you only need one direction.
+  In `audio` mode, provide `output_url` to receive meeting audio, `input_url` to send audio into the meeting, or both for bidirectional streaming - set either to `null` if you only need one direction. In `transcription` mode, `output_url` is required (bot creation fails without it) and receives JSON transcript messages instead of raw audio.
 </Callout>
 
 ## Streaming Modes
@@ -182,14 +182,18 @@ Your WebSocket server receives JSON text messages, one per transcript segment. E
 | `event` | `string` | Always `"transcript.segment"` - the only event type sent in transcription mode |
 | `bot_id` | `string` | UUID of the bot |
 | `data.text` | `string` | Transcribed text for this segment |
-| `data.isFinal` | `boolean` | `false` for partial (interim) segments, `true` for final segments. Partial segments may be revised by a later message covering the same utterance |
+| `data.isFinal` | `boolean` | `false` for partial (interim) segments, `true` for final segments (see [Partial vs. Final Segments](#partial-vs-final-segments)) |
 | `data.utteranceStart` | `number` | Utterance start time in seconds |
 | `data.utteranceEnd` | `number` | Utterance end time in seconds |
 | `data.confidence` | `number` | Overall confidence score for the segment (0-1), when the provider reports one |
 | `data.words` | `array` | Word-level timings: `{ text, start, end, confidence?, speaker? }` |
 | `data.speaker` | `object \| null` | Active speaker at the time of the segment: `{ name, id }`, or `null` when unknown |
 
-Fields other than `event` may be absent depending on the STT provider - treat them as optional.
+The `event` and `bot_id` envelope fields are always present. Fields under `data` are provider-dependent - treat all of them as optional.
+
+#### Partial vs. Final Segments
+
+Messages carry no explicit segment or utterance identifier. Partial segments (`isFinal: false`) are progressive snapshots of the utterance currently being spoken - each new partial for that utterance replaces the previous one, and the final segment (`isFinal: true`) supersedes all partials for it. Correlate them by time: partials and their final cover overlapping `utteranceStart`/`utteranceEnd` ranges. The simplest robust approach is to use partials for live display only (always replacing the last partial shown) and build your stored transcript exclusively from `isFinal: true` segments.
 
 If the WebSocket connection drops, the bot reconnects with exponential backoff (1s doubling up to 60s) and buffers up to 100 transcript events while disconnected, flushing them on reconnect. Events beyond the buffer limit are dropped.
 

--- a/openapi-v2.json
+++ b/openapi-v2.json
@@ -4105,6 +4105,18 @@
             "description": "An optional extra configuration object for the bot.\n\nThis object can contain any custom key-value pairs that you want to associate with the bot. The data will be:\n\n- Included in all webhook event payloads (if a webhook endpoint is configured)\n- Part of the callback payload (if callback is enabled)\n- Returned when fetching the bot's details via the API\n\nUseful for storing custom metadata, tracking information, or any other data you need to correlate with the bot.",
             "example": null
           },
+          "ignored_participant_names": {
+            "default": [],
+            "description": "Participant names to ignore when evaluating auto-leave conditions.\n\nThe bot will not count participants matching these names when determining whether to leave a meeting. This is useful when multiple bots may join the same meeting across different environments (e.g., sandbox, staging).\n\nBy ignoring other bots' participant names, each bot can correctly detect when human participants have left and leave the meeting rather than remaining indefinitely.",
+            "example": [
+              "Sandbox Bot",
+              "Staging Bot"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "meet_config": {
             "anyOf": [
               {
@@ -4218,7 +4230,7 @@
                   },
                   "mode": {
                     "default": "audio",
-                    "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and POSTs transcript events to output_url via HTTP webhooks.",
+                    "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and sends transcript events to output_url over a WebSocket connection, as JSON messages with event 'transcript.segment'.",
                     "enum": [
                       "audio",
                       "transcription"
@@ -4236,7 +4248,7 @@
                       }
                     ],
                     "default": null,
-                    "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': HTTP URL where transcript events are POSTed.",
+                    "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': WebSocket URL where the bot sends transcript events as JSON messages with event 'transcript.segment'.",
                     "example": null
                   },
                   "transcription": {
@@ -4357,9 +4369,9 @@
               },
               "silence_timeout": {
                 "default": 600,
-                "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 30 minutes",
+                "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 60 minutes",
                 "example": 600,
-                "maximum": 1800,
+                "maximum": 3600,
                 "minimum": 300,
                 "type": "integer"
               },
@@ -4718,6 +4730,18 @@
                 "description": "An optional extra configuration object for the bot.\n\nThis object can contain any custom key-value pairs that you want to associate with the bot. The data will be:\n\n- Included in all webhook event payloads (if a webhook endpoint is configured)\n- Part of the callback payload (if callback is enabled)\n- Returned when fetching the bot's details via the API\n\nUseful for storing custom metadata, tracking information, or any other data you need to correlate with the bot.",
                 "example": null
               },
+              "ignored_participant_names": {
+                "default": [],
+                "description": "Participant names to ignore when evaluating auto-leave conditions.\n\nThe bot will not count participants matching these names when determining whether to leave a meeting. This is useful when multiple bots may join the same meeting across different environments (e.g., sandbox, staging).\n\nBy ignoring other bots' participant names, each bot can correctly detect when human participants have left and leave the meeting rather than remaining indefinitely.",
+                "example": [
+                  "Sandbox Bot",
+                  "Staging Bot"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "meet_config": {
                 "anyOf": [
                   {
@@ -4827,7 +4851,7 @@
                       },
                       "mode": {
                         "default": "audio",
-                        "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and POSTs transcript events to output_url via HTTP webhooks.",
+                        "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and sends transcript events to output_url over a WebSocket connection, as JSON messages with event 'transcript.segment'.",
                         "enum": [
                           "audio",
                           "transcription"
@@ -4845,7 +4869,7 @@
                           }
                         ],
                         "default": null,
-                        "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': HTTP URL where transcript events are POSTed.",
+                        "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': WebSocket URL where the bot sends transcript events as JSON messages with event 'transcript.segment'.",
                         "example": null
                       },
                       "transcription": {
@@ -4981,9 +5005,9 @@
                   },
                   "silence_timeout": {
                     "default": 600,
-                    "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 30 minutes",
+                    "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 60 minutes",
                     "example": 600,
-                    "maximum": 1800,
+                    "maximum": 3600,
                     "minimum": 300,
                     "type": "integer"
                   },
@@ -5135,6 +5159,7 @@
               "bot_name",
               "bot_image",
               "bot_image_config",
+              "ignored_participant_names",
               "recording_mode",
               "entry_message",
               "timeout_config",
@@ -5330,6 +5355,18 @@
                 "description": "An optional extra configuration object for the bot.\n\nThis object can contain any custom key-value pairs that you want to associate with the bot. The data will be:\n\n- Included in all webhook event payloads (if a webhook endpoint is configured)\n- Part of the callback payload (if callback is enabled)\n- Returned when fetching the bot's details via the API\n\nUseful for storing custom metadata, tracking information, or any other data you need to correlate with the bot.",
                 "example": null
               },
+              "ignored_participant_names": {
+                "default": [],
+                "description": "Participant names to ignore when evaluating auto-leave conditions.\n\nThe bot will not count participants matching these names when determining whether to leave a meeting. This is useful when multiple bots may join the same meeting across different environments (e.g., sandbox, staging).\n\nBy ignoring other bots' participant names, each bot can correctly detect when human participants have left and leave the meeting rather than remaining indefinitely.",
+                "example": [
+                  "Sandbox Bot",
+                  "Staging Bot"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "meet_config": {
                 "anyOf": [
                   {
@@ -5437,7 +5474,7 @@
                       },
                       "mode": {
                         "default": "audio",
-                        "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and POSTs transcript events to output_url via HTTP webhooks.",
+                        "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and sends transcript events to output_url over a WebSocket connection, as JSON messages with event 'transcript.segment'.",
                         "enum": [
                           "audio",
                           "transcription"
@@ -5455,7 +5492,7 @@
                           }
                         ],
                         "default": null,
-                        "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': HTTP URL where transcript events are POSTed.",
+                        "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': WebSocket URL where the bot sends transcript events as JSON messages with event 'transcript.segment'.",
                         "example": null
                       },
                       "transcription": {
@@ -5576,9 +5613,9 @@
                   },
                   "silence_timeout": {
                     "default": 600,
-                    "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 30 minutes",
+                    "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 60 minutes",
                     "example": 600,
-                    "maximum": 1800,
+                    "maximum": 3600,
                     "minimum": 300,
                     "type": "integer"
                   },
@@ -6709,6 +6746,53 @@
                 "description": "The name of the bot",
                 "type": "string"
               },
+              "callback_config": {
+                "anyOf": [
+                  {
+                    "additionalProperties": false,
+                    "properties": {
+                      "enabled": {
+                        "const": true,
+                        "type": "boolean"
+                      },
+                      "method": {
+                        "description": "HTTP method for callback",
+                        "enum": [
+                          "POST",
+                          "PUT"
+                        ],
+                        "type": "string"
+                      },
+                      "secret": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "description": "Secret for validating callbacks (null if not set)"
+                      },
+                      "url": {
+                        "description": "Callback URL",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "enabled",
+                      "url",
+                      "secret",
+                      "method"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Callback configuration (null if callback is disabled)"
+              },
               "chat_messages": {
                 "anyOf": [
                   {
@@ -7166,7 +7250,8 @@
               "tokens",
               "extra",
               "zoom_config",
-              "meet_login_credential_id"
+              "meet_login_credential_id",
+              "callback_config"
             ],
             "type": "object"
           },
@@ -7213,6 +7298,52 @@
                 "description": "The name of the bot",
                 "type": "string"
               },
+              "callback_config": {
+                "anyOf": [
+                  {
+                    "properties": {
+                      "enabled": {
+                        "const": true,
+                        "type": "boolean"
+                      },
+                      "method": {
+                        "description": "HTTP method for callback",
+                        "enum": [
+                          "POST",
+                          "PUT"
+                        ],
+                        "type": "string"
+                      },
+                      "secret": {
+                        "anyOf": [
+                          {
+                            "type": "string"
+                          },
+                          {
+                            "type": "null"
+                          }
+                        ],
+                        "description": "Secret for validating callbacks (null if not set)"
+                      },
+                      "url": {
+                        "description": "Callback URL",
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "enabled",
+                      "url",
+                      "secret",
+                      "method"
+                    ],
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "description": "Callback configuration (null if callback is disabled)"
+              },
               "chat_messages": {
                 "anyOf": [
                   {
@@ -7666,7 +7797,8 @@
               "tokens",
               "extra",
               "zoom_config",
-              "meet_login_credential_id"
+              "meet_login_credential_id",
+              "callback_config"
             ],
             "type": "object"
           },
@@ -11660,7 +11792,7 @@
                       "type": "number"
                     },
                     "language": {
-                      "description": "ISO 639-1 language code (e.g., 'en', 'es')",
+                      "description": "ISO 639-1 language code (e.g., 'en', 'es'). Only present when the transcription provider reported a language for this utterance.",
                       "type": "string"
                     },
                     "speaker": {
@@ -11712,7 +11844,6 @@
                   },
                   "required": [
                     "text",
-                    "language",
                     "start",
                     "end",
                     "confidence",
@@ -11801,7 +11932,7 @@
                       "type": "number"
                     },
                     "language": {
-                      "description": "ISO 639-1 language code (e.g., 'en', 'es')",
+                      "description": "ISO 639-1 language code (e.g., 'en', 'es'). Only present when the transcription provider reported a language for this utterance.",
                       "type": "string"
                     },
                     "speaker": {
@@ -11852,7 +11983,6 @@
                   },
                   "required": [
                     "text",
-                    "language",
                     "start",
                     "end",
                     "confidence",
@@ -12842,6 +12972,18 @@
                 "description": "An optional extra configuration object for the bot.\n\nThis object can contain any custom key-value pairs that you want to associate with the bot. The data will be:\n\n- Included in all webhook event payloads (if a webhook endpoint is configured)\n- Part of the callback payload (if callback is enabled)\n- Returned when fetching the bot's details via the API\n\nUseful for storing custom metadata, tracking information, or any other data you need to correlate with the bot.",
                 "example": null
               },
+              "ignored_participant_names": {
+                "default": [],
+                "description": "Participant names to ignore when evaluating auto-leave conditions.\n\nThe bot will not count participants matching these names when determining whether to leave a meeting. This is useful when multiple bots may join the same meeting across different environments (e.g., sandbox, staging).\n\nBy ignoring other bots' participant names, each bot can correctly detect when human participants have left and leave the meeting rather than remaining indefinitely.",
+                "example": [
+                  "Sandbox Bot",
+                  "Staging Bot"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "meet_config": {
                 "anyOf": [
                   {
@@ -12950,7 +13092,7 @@
                   },
                   "mode": {
                     "default": "audio",
-                    "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and POSTs transcript events to output_url via HTTP webhooks.",
+                    "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and sends transcript events to output_url over a WebSocket connection, as JSON messages with event 'transcript.segment'.",
                     "enum": [
                       "audio",
                       "transcription"
@@ -12968,7 +13110,7 @@
                       }
                     ],
                     "default": null,
-                    "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': HTTP URL where transcript events are POSTed.",
+                    "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': WebSocket URL where the bot sends transcript events as JSON messages with event 'transcript.segment'.",
                     "example": null
                   },
                   "transcription": {
@@ -13097,9 +13239,9 @@
                   },
                   "silence_timeout": {
                     "default": 600,
-                    "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 30 minutes",
+                    "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 60 minutes",
                     "example": 600,
-                    "maximum": 1800,
+                    "maximum": 3600,
                     "minimum": 300,
                     "type": "integer"
                   },
@@ -13413,6 +13555,18 @@
                 "description": "An optional extra configuration object for the bot.\n\nThis object can contain any custom key-value pairs that you want to associate with the bot. The data will be:\n\n- Included in all webhook event payloads (if a webhook endpoint is configured)\n- Part of the callback payload (if callback is enabled)\n- Returned when fetching the bot's details via the API\n\nUseful for storing custom metadata, tracking information, or any other data you need to correlate with the bot.",
                 "example": null
               },
+              "ignored_participant_names": {
+                "default": [],
+                "description": "Participant names to ignore when evaluating auto-leave conditions.\n\nThe bot will not count participants matching these names when determining whether to leave a meeting. This is useful when multiple bots may join the same meeting across different environments (e.g., sandbox, staging).\n\nBy ignoring other bots' participant names, each bot can correctly detect when human participants have left and leave the meeting rather than remaining indefinitely.",
+                "example": [
+                  "Sandbox Bot",
+                  "Staging Bot"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "meet_config": {
                 "anyOf": [
                   {
@@ -13519,7 +13673,7 @@
                   },
                   "mode": {
                     "default": "audio",
-                    "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and POSTs transcript events to output_url via HTTP webhooks.",
+                    "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and sends transcript events to output_url over a WebSocket connection, as JSON messages with event 'transcript.segment'.",
                     "enum": [
                       "audio",
                       "transcription"
@@ -13537,7 +13691,7 @@
                       }
                     ],
                     "default": null,
-                    "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': HTTP URL where transcript events are POSTed.",
+                    "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': WebSocket URL where the bot sends transcript events as JSON messages with event 'transcript.segment'.",
                     "example": null
                   },
                   "transcription": {
@@ -13651,9 +13805,9 @@
                   },
                   "silence_timeout": {
                     "default": 600,
-                    "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 30 minutes",
+                    "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 60 minutes",
                     "example": 600,
-                    "maximum": 1800,
+                    "maximum": 3600,
                     "minimum": 300,
                     "type": "integer"
                   },
@@ -14287,6 +14441,18 @@
             "description": "An optional extra configuration object for the bot.\n\nThis object can contain any custom key-value pairs that you want to associate with the bot. The data will be:\n\n- Included in all webhook event payloads (if a webhook endpoint is configured)\n- Part of the callback payload (if callback is enabled)\n- Returned when fetching the bot's details via the API\n\nUseful for storing custom metadata, tracking information, or any other data you need to correlate with the bot.",
             "example": null
           },
+          "ignored_participant_names": {
+            "default": [],
+            "description": "Participant names to ignore when evaluating auto-leave conditions.\n\nThe bot will not count participants matching these names when determining whether to leave a meeting. This is useful when multiple bots may join the same meeting across different environments (e.g., sandbox, staging).\n\nBy ignoring other bots' participant names, each bot can correctly detect when human participants have left and leave the meeting rather than remaining indefinitely.",
+            "example": [
+              "Sandbox Bot",
+              "Staging Bot"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "join_at": {
             "description": "Update the scheduled join time.\n\nISO8601 format. Must be at least 4 minutes in the future and cannot be more than 90 days in the future.\n\nExample: \"2025-12-25T10:00:00Z\"",
             "format": "date-time",
@@ -14408,7 +14574,7 @@
                   },
                   "mode": {
                     "default": "audio",
-                    "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and POSTs transcript events to output_url via HTTP webhooks.",
+                    "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and sends transcript events to output_url over a WebSocket connection, as JSON messages with event 'transcript.segment'.",
                     "enum": [
                       "audio",
                       "transcription"
@@ -14426,7 +14592,7 @@
                       }
                     ],
                     "default": null,
-                    "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': HTTP URL where transcript events are POSTed.",
+                    "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': WebSocket URL where the bot sends transcript events as JSON messages with event 'transcript.segment'.",
                     "example": null
                   },
                   "transcription": {
@@ -14562,9 +14728,9 @@
               },
               "silence_timeout": {
                 "default": 600,
-                "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 30 minutes",
+                "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 60 minutes",
                 "example": 600,
-                "maximum": 1800,
+                "maximum": 3600,
                 "minimum": 300,
                 "type": "integer"
               },
@@ -14868,6 +15034,18 @@
             "description": "An optional extra configuration object for the bot.\n\nThis object can contain any custom key-value pairs that you want to associate with the bot. The data will be:\n\n- Included in all webhook event payloads (if a webhook endpoint is configured)\n- Part of the callback payload (if callback is enabled)\n- Returned when fetching the bot's details via the API\n\nUseful for storing custom metadata, tracking information, or any other data you need to correlate with the bot.",
             "example": null
           },
+          "ignored_participant_names": {
+            "default": [],
+            "description": "Participant names to ignore when evaluating auto-leave conditions.\n\nThe bot will not count participants matching these names when determining whether to leave a meeting. This is useful when multiple bots may join the same meeting across different environments (e.g., sandbox, staging).\n\nBy ignoring other bots' participant names, each bot can correctly detect when human participants have left and leave the meeting rather than remaining indefinitely.",
+            "example": [
+              "Sandbox Bot",
+              "Staging Bot"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "join_at": {
             "description": "Update the scheduled join time.\n\nISO8601 format. Must be at least 4 minutes in the future and cannot be more than 90 days in the future.\n\nExample: \"2025-12-25T10:00:00Z\"",
             "format": "date-time",
@@ -14987,7 +15165,7 @@
                   },
                   "mode": {
                     "default": "audio",
-                    "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and POSTs transcript events to output_url via HTTP webhooks.",
+                    "description": "The streaming mode. 'audio' (default) streams raw audio to output_url via WebSocket. 'transcription' runs real-time speech-to-text and sends transcript events to output_url over a WebSocket connection, as JSON messages with event 'transcript.segment'.",
                     "enum": [
                       "audio",
                       "transcription"
@@ -15005,7 +15183,7 @@
                       }
                     ],
                     "default": null,
-                    "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': HTTP URL where transcript events are POSTed.",
+                    "description": "When mode is 'audio': WebSocket URL where the bot sends raw audio. When mode is 'transcription': WebSocket URL where the bot sends transcript events as JSON messages with event 'transcript.segment'.",
                     "example": null
                   },
                   "transcription": {
@@ -15126,9 +15304,9 @@
               },
               "silence_timeout": {
                 "default": 600,
-                "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 30 minutes",
+                "description": "The timeout in seconds for the bot to wait for silence before leaving the meeting.\n\nIf no audio is detected for this duration after the bot joins, the bot will leave the meeting. Only applicable for Google Meet and Microsoft Teams meetings.\n\nDefault: 600 seconds (10 minutes)\nMinimum: 5 minutes\nMaximum: 60 minutes",
                 "example": 600,
-                "maximum": 1800,
+                "maximum": 3600,
                 "minimum": 300,
                 "type": "integer"
               },
@@ -21639,7 +21817,7 @@
         ]
       },
       "post": {
-        "description": "Create a meet login — a Google Workspace user identity attached to a parent meet workspace.\n\n    Each login represents one Workspace user that bots can sign in as. Many logins can share one workspace; they all use the workspace's cert/key for SAML signing. Round-robin assignment picks the least-loaded active login when a bot is dispatched with `meet_config.email_group` (or `credential_id`) on `POST /v2/bots`.\n\n    **Prerequisites:** Create a meet workspace first via `POST /v2/meet-workspaces`. Pass the returned `workspace_id` here.\n\n    **Domain Validation:** The `email` must belong to the parent workspace's domain (or a subdomain). For example, if the workspace domain is `bots.acme.com`, valid emails include `bot1@bots.acme.com` or `bot2@dev.bots.acme.com`, but not `bot1@acme.com`. The same rule applies to `email_group` if provided.\n\n    **Email Group (optional but encouraged):** Set `email_group` to a Google Group address that contains the bot users as members. When you put this group address on a calendar invite, the assigned bot lands in Meet's verified queue and bypasses the waiting room. Logins sharing the same `email_group` form one round-robin pool.\n\n    **Per-team Uniqueness on Email:** Each `email` may exist at most once per team. Attempting to register the same email twice returns 409.\n\n    **Concurrency:** Each login supports up to 20 concurrent SSO sessions. When a login hits its capacity, the round-robin assigner skips it and tries the next one in the pool. If all logins in a pool are saturated, the bot creation fails with `MEET_LOGIN_UNAVAILABLE` (or falls back to anonymous, depending on your `fallback` setting).\n\n    **Error Scenarios:**\n    - `404 Not Found`: `workspace_id` is unknown or does not belong to your team.\n    - `409 Conflict`: A login for this `email` already exists.\n    - `422 Unprocessable Entity`: `email` or `email_group` domain does not match the parent workspace's domain.",
+        "description": "Create a meet login — a Google Workspace user identity attached to a parent meet workspace.\n\n    Each login represents one Workspace user that bots can sign in as. Many logins can share one workspace; they all use the workspace's cert/key for SAML signing. Round-robin assignment picks the least-loaded active login when a bot is dispatched with `meet_config.email_group` (or `credential_id`) on `POST /v2/bots`.\n\n    **Prerequisites:** Create a meet workspace first via `POST /v2/meet-workspaces`. Pass the returned `workspace_id` here.\n\n    **Domain Validation:** The `email` must belong to the parent workspace's domain (or a subdomain). For example, if the workspace domain is `bots.acme.com`, valid emails include `bot1@bots.acme.com` or `bot2@dev.bots.acme.com`, but not `bot1@acme.com`. The same rule applies to `email_group` if provided.\n\n    **Email Group (optional but encouraged):** Set `email_group` to a Google Group address that contains the bot users as members. When you put this group address on a calendar invite, the assigned bot lands in Meet's verified queue and bypasses the waiting room. Logins sharing the same `email_group` form one round-robin pool.\n\n    **Per-team Uniqueness on Email:** Each `email` may exist at most once per team. Attempting to register the same email twice returns 409.\n\n    **Concurrency:** Each login supports up to 20 concurrent SSO sessions by default. When a login hits its capacity, the round-robin assigner skips it and tries the next one in the pool. If all logins in a pool are saturated, the bot creation fails with `MEET_LOGIN_UNAVAILABLE` (or falls back to anonymous, depending on your `fallback` setting).\n\n    **Error Scenarios:**\n    - `404 Not Found`: `workspace_id` is unknown or does not belong to your team.\n    - `409 Conflict`: A login for this `email` already exists.\n    - `422 Unprocessable Entity`: `email` or `email_group` domain does not match the parent workspace's domain.",
         "operationId": "createMeetLogin",
         "requestBody": {
           "content": {


### PR DESCRIPTION
## Why

Customer report (Celso Palmeira, Jul 16): with `streaming_config.mode: "transcription"`, the docs said transcript events are HTTP POSTed to `output_url`, but the voice-router forwarder actually opens a **WebSocket** to it (`apps/voice-router/src/forwarding/ws-forwarder.ts`). His endpoint got a WS upgrade and 502'd. Support confirmed the behavior; docs were the ones wrong.

## What

- **`streaming.mdx`**: transcription mode now documented as WebSocket delivery (`wss://` example), with the full `transcript.segment` message schema (envelope, `isFinal` partial/final semantics, word timings, speaker object), plus reconnect backoff (1s→60s) and the 100-event disconnect buffer — all verified against the forwarder code in meeting-baas-v2.
- **`openapi-v2.json`**: synced from prod (`scripts/update-openapi-v2.sh`). Prod spec already carries the corrected WebSocket descriptions.
- **API reference pages**: regenerated from the new spec (`ignored_participant_names`, `silence_timeout` max 3600, `callback_config` in bot details, optional utterance `language`, meet-login concurrency wording).
- **`sending-a-bot.mdx`**: `silence_timeout` max 1800 → 3600; documented new `ignored_participant_names` option.

MDX compiles (`fumadocs-mdx` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)