### PR TITLE
docs(streaming): live vs batch custom_params + transcription session events

### DIFF
--- a/content/docs/api-v2/streaming.mdx
+++ b/content/docs/api-v2/streaming.mdx
@@ -148,12 +148,55 @@ The `streaming_config.transcription` object configures the real-time STT provide
 |-------|------|---------|-------------|
 | `provider` | `string` | `gladia` | Real-time STT provider: `gladia`, `deepgram`, `assemblyai`, `speechmatics`, `soniox`, or `elevenlabs` (streaming-only) |
 | `api_key` | `string \| null` | `null` | Your provider API key (BYOK). Leave `null` to use the platform key |
-| `custom_params` | `object \| null` | `null` | Provider-specific advanced options |
+| `custom_params` | `object \| null` | `null` | Provider-specific advanced options, forwarded to the provider's **live session API** (see [Custom Parameters](#custom-parameters-live-vs-batch)) |
 | `region` | `string \| null` | `null` | Provider API region. When omitted, provider defaults apply (`gladia=eu-west`, `deepgram=eu`, `assemblyai=eu`, `speechmatics=eu1`, `soniox=us`, `elevenlabs=global`) |
 
 <Callout type="info">
   All [batch transcription providers](/docs/api-v2/transcription#transcription-providers) are available for real-time streaming, plus **ElevenLabs**, which is streaming-only. In `transcription` mode, `output_url` is still a **WebSocket** endpoint (`wss://`) - the bot opens a WebSocket connection to it and sends JSON text messages. It does not send HTTP POST requests.
 </Callout>
+
+#### Custom Parameters (live vs. batch)
+
+`custom_params` is forwarded to the provider's **live session API** - for Gladia, that is [`POST /v2/live`](https://docs.gladia.io/api-reference/v2/live/init), not the [pre-recorded API](https://docs.gladia.io/api-reference/v2/pre-recorded/init) used for [batch transcription](/docs/api-v2/transcription). The two APIs accept **different shapes**, and reusing batch-shaped params is the most common mistake: for example, Gladia's live API nests translation under `realtime_processing`, while the batch API takes `translation_config` at the top level.
+
+```json
+{
+  "streaming_config": {
+    "mode": "transcription",
+    "output_url": "wss://your-server.com/transcripts",
+    "transcription": {
+      "provider": "gladia",
+      "custom_params": {
+        "language_config": { "languages": ["ru"] },
+        "realtime_processing": {
+          "translation": true,
+          "translation_config": { "target_languages": ["en", "de", "it"] }
+        }
+      }
+    }
+  }
+}
+```
+
+`custom_params` is validated against the provider's live schema when you create the bot - unknown fields are rejected with a `400` that points at the correct live-API location where one exists (e.g. `translation_config` → `realtime_processing.translation_config`).
+
+<Callout type="warn">
+  `encoding`, `sample_rate`, `bit_depth` and `channels` are set by the platform and cannot be overridden through `custom_params`. To control the audio sample rate, use `streaming_config.audio_frequency`.
+</Callout>
+
+#### Transcription Session Events
+
+In `transcription` mode, the bot sends three event types to `output_url`, all sharing the `{ "event", "bot_id", "data" }` envelope:
+
+| Event | When | `data` |
+|-------|------|--------|
+| `session.started` | The provider transcription session is live - transcript segments will follow | `{ "provider": "gladia" }` |
+| `transcript.segment` | One per transcript piece (partial and final) | See [Transcript Events](#transcript-events) |
+| `error` | The transcription session failed to start or died mid-meeting | `{ "code": "transcription_session_failed", "message": "..." }` |
+
+If you receive `error`, live transcription is down for the rest of the meeting - the `message` field carries the provider's reason (e.g. rejected parameters). Recording and [batch transcription](/docs/api-v2/transcription) are unaffected. Treat a connection that never receives `session.started` as not yet live rather than silent.
+
+The bot also sends standard WebSocket ping frames roughly every 30 seconds so intermediaries (e.g. Cloudflare tunnels, which drop idle connections after ~100s) keep the connection open through quiet stretches of the meeting. Most WebSocket libraries answer pings automatically - no action needed.
 
 #### Transcript Events
 
@@ -179,7 +222,7 @@ Your WebSocket server receives JSON text messages, one per transcript segment. E
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `event` | `string` | Always `"transcript.segment"` - the only event type sent in transcription mode |
+| `event` | `string` | `"transcript.segment"` for transcript messages (see [Transcription Session Events](#transcription-session-events) for the other event types) |
 | `bot_id` | `string` | UUID of the bot |
 | `data.text` | `string` | Transcribed text for this segment |
 | `data.isFinal` | `boolean` | `false` for partial (interim) segments, `true` for final segments (see [Partial vs. Final Segments](#partial-vs-final-segments)) |

--- a/content/docs/api-v2/streaming.mdx
+++ b/content/docs/api-v2/streaming.mdx
@@ -180,6 +180,17 @@ The `streaming_config.transcription` object configures the real-time STT provide
 
 `custom_params` is validated against the provider's live schema when you create the bot - unknown fields are rejected with a `400` that points at the correct live-API location where one exists (e.g. `translation_config` → `realtime_processing.translation_config`).
 
+The same batch-vs-live distinction applies to every provider - always use the provider's **real-time/streaming** parameter reference, not the pre-recorded one:
+
+| Provider | Live API parameters |
+|----------|--------------------|
+| Gladia | [Live init](https://docs.gladia.io/api-reference/v2/live/init) |
+| Deepgram | [Streaming API](https://developers.deepgram.com/docs/streaming) |
+| AssemblyAI | [Streaming Speech-to-Text](https://www.assemblyai.com/docs/speech-to-text/streaming) |
+| Speechmatics | [Real-Time API](https://docs.speechmatics.com/rt-api-ref) |
+| Soniox | [Real-Time API](https://soniox.com/docs) |
+| ElevenLabs | [Speech-to-Text](https://elevenlabs.io/docs/capabilities/speech-to-text) (params not validated at creation - errors surface via the `error` event) |
+
 <Callout type="warn">
   `encoding`, `sample_rate`, `bit_depth` and `channels` are set by the platform and cannot be overridden through `custom_params`. To control the audio sample rate, use `streaming_config.audio_frequency`.
 </Callout>

--- a/content/docs/api-v2/transcription.mdx
+++ b/content/docs/api-v2/transcription.mdx
@@ -61,8 +61,8 @@ In addition to all of the batch providers above, real-time streaming transcripti
 
 - **ElevenLabs**
 
-<Callout type="info">
-  Provider-specific advanced options are passed through `custom_params`. The available options depend on the provider you select.
+<Callout type="warn">
+  Batch and real-time streaming use **different provider APIs with different `custom_params` shapes**. The parameters documented on this page apply to **batch** transcription (e.g. Gladia's [pre-recorded API](https://docs.gladia.io/api-reference/v2/pre-recorded/init)). For `streaming_config.transcription.custom_params`, use the provider's **live API** shape instead (e.g. Gladia's [live API](https://docs.gladia.io/api-reference/v2/live/init), where translation is nested under `realtime_processing`) - see [Streaming: Custom Parameters](/docs/api-v2/streaming#custom-parameters-live-vs-batch).
 </Callout>
 
 ## Bring Your Own Key (BYOK)
@@ -99,7 +99,7 @@ BYOK transcription is available on **Pro plans and above**. Pay-as-you-go plans 
 
 v2 supports advanced transcription features through custom parameters. These are provider-specific options that enhance transcription capabilities.
 
-For complete documentation on all available custom parameters, see the [Gladia API Reference](https://docs.gladia.io/api-reference/v2/pre-recorded/init).
+For complete documentation on all available custom parameters, see the [Gladia API Reference](https://docs.gladia.io/api-reference/v2/pre-recorded/init). These shapes apply to **batch** transcription only - for real-time streaming, see [Streaming: Custom Parameters](/docs/api-v2/streaming#custom-parameters-live-vs-batch).
 
 ### Available Custom Parameters
 


### PR DESCRIPTION
## Why

Customer bug (v2 live transcription ticket, bots 592af8a3 / b5e0540b): `streaming_config.transcription.custom_params` is forwarded to the provider's **live** session API, but the docs only ever showed **batch**-shaped params. The customer reused Gladia batch params (top-level `translation`/`translation_config`), Gladia's `POST /v2/live` rejected them with a 400, and the meeting produced zero transcript events with no error surfaced.

## What

- **streaming.mdx**
  - New *Custom Parameters (live vs. batch)* section: live-API shape, worked Gladia translation example (`realtime_processing`), creation-time validation behavior, platform-managed fields (`encoding`/`sample_rate`/`bit_depth`/`channels`).
  - New *Transcription Session Events* section: `session.started`, `transcript.segment`, `error` envelopes + the ~30s WebSocket keepalive pings.
  - Fixed the claim that `transcript.segment` is the only event type.
- **transcription.mdx**: callout + note that this page's custom_params are **batch-only**, with links to the Gladia live API and the new streaming section.

## Notes

- Pairs with the API-side PR in meeting-baas-v2 (strict live-schema validation at bot creation + error/session.started events + keepalive). The new events/validation land with that deploy — suggest merging this once that PR is deployed.
- `openapi-v2.json` regen not needed here: committed spec already carries the WebSocket delivery wording; the new field descriptions will flow in on the next scheduled spec refresh after the API deploy.
- `scripts/lint.mts`: both edited files pass; the 21 reported errors are pre-existing on main (other files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)