### PR TITLE
fix(docs): surface storage API reference pages in navigation

### DIFF
--- a/content/docs/api-v2/reference/meta.json
+++ b/content/docs/api-v2/reference/meta.json
@@ -10,6 +10,7 @@
         "meet-workspaces",
         "meet-logins",
         "teams-workspaces",
-        "teams-logins"
+        "teams-logins",
+        "storage"
     ]
 }

--- a/content/docs/api-v2/reference/storage/meta.json
+++ b/content/docs/api-v2/reference/storage/meta.json
@@ -1,0 +1,9 @@
+{
+    "title": "Storage",
+    "pages": [
+        "getStorageConfig",
+        "setStorageConfig",
+        "testStorageConfig",
+        "deleteStorageConfig"
+    ]
+}

--- a/content/docs/bring-your-own-storage/index.mdx
+++ b/content/docs/bring-your-own-storage/index.mdx
@@ -50,10 +50,10 @@ storage with zero change.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/v2/storage-config` | Get current configuration (404 if unset) |
-| `PUT` | `/v2/storage-config` | Set or replace configuration |
-| `POST` | `/v2/storage-config/test` | Re-run the access check |
-| `DELETE` | `/v2/storage-config` | Disable — new bots go back to Meeting BaaS storage. Nothing is deleted. |
+| `GET` | [`/v2/storage-config`](/docs/api-v2/reference/storage/getStorageConfig) | Get current configuration (404 if unset) |
+| `PUT` | [`/v2/storage-config`](/docs/api-v2/reference/storage/setStorageConfig) | Set or replace configuration |
+| `POST` | [`/v2/storage-config/test`](/docs/api-v2/reference/storage/testStorageConfig) | Re-run the access check |
+| `DELETE` | [`/v2/storage-config`](/docs/api-v2/reference/storage/deleteStorageConfig) | Disable — new bots go back to Meeting BaaS storage. Nothing is deleted. |
 
 The same endpoints are available at `/bff/storage-config` for dashboard auth.
 

--- a/content/docs/bring-your-own-storage/meta.json
+++ b/content/docs/bring-your-own-storage/meta.json
@@ -3,5 +3,12 @@
   "icon": "HardDrive",
   "description": "Connect your own S3-compatible object storage to Meeting BaaS.",
   "root": true,
-  "pages": ["index"]
+  "pages": [
+    "index",
+    "---API Reference---",
+    "[Get storage config](/docs/api-v2/reference/storage/getStorageConfig)",
+    "[Set storage config](/docs/api-v2/reference/storage/setStorageConfig)",
+    "[Test storage config](/docs/api-v2/reference/storage/testStorageConfig)",
+    "[Delete storage config](/docs/api-v2/reference/storage/deleteStorageConfig)"
+  ]
 }


### PR DESCRIPTION
## Why

The storage endpoints landed in the prod v2 spec and the OpenAPI sync automation (#150, first run `a4f9bfa`) generated their reference pages — but `content/docs/api-v2/reference/meta.json` whitelists which sections appear in the sidebar and had no `storage` entry. The pages were live yet only reachable by direct URL:

- `/api-v2/reference/storage/getStorageConfig`
- `/api-v2/reference/storage/setStorageConfig`
- `/api-v2/reference/storage/testStorageConfig`
- `/api-v2/reference/storage/deleteStorageConfig`

## What

- Add `storage` to the API Reference section list.
- Add `reference/storage/meta.json` (title + page order), matching sibling sections.
- Link the endpoint table on the [Bring Your Own Storage](https://docs.meetingbaas.com/bring-your-own-storage) page to the reference pages.

Note: this whitelist means every future new tag in the spec needs the same manual meta.json addition — flagging in case we want the generator to warn on unlisted sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)