### PR TITLE
docs(meet-sso): fix setup-order deadlock in the Meet SSO guide

### DIFF
--- a/content/docs/api-v2/authenticated-bots/meet/setup.mdx
+++ b/content/docs/api-v2/authenticated-bots/meet/setup.mdx
@@ -172,6 +172,10 @@ Set **Select SSO profile** to **Legacy SSO profile**, then click **Override** (o
 <Callout type="warn">
 Assign the profile to the bot group/OU **only**. Never assign it to a scope that contains real users, or they will be redirected through the bot IdP. Changes take a few minutes to take effect.
 </Callout>
+
+<Callout type="warn">
+**Complete each bot account's first login *before* it enters this SSO scope** (see [Step 3](#step-3--prepare-the-workspace-users)). Once an account is covered by the profile, Google routes *every* sign-in — including the very first one — to the Meeting BaaS IdP, which only bots can complete. A human can then no longer finish the "Welcome to Workspace" flow. If you scoped a whole domain (the recommended dedicated-domain setup), assign the profile **after** preparing the users, or temporarily exclude an account while you complete its first login.
+</Callout>
 </Step>
 
 </Steps>
@@ -183,6 +187,14 @@ For **each** Google account the bots will sign in as:
 1. Create the user in Google Admin Console (for example `bot1@bots.acme.com`).
 2. Sign in to that account once interactively and complete the **"Welcome to Workspace"** flow. This first-time interactive login is required before the account can be used programmatically — skipping it causes the login to flip to `invalid` on first use.
 3. Set the account language to **English (United States)** to ensure the sign-in and Meet UIs are in the expected state.
+
+<Callout type="warn">
+**Do the interactive first login while the account is *not yet* covered by the Legacy SSO profile.** An account already in SSO scope cannot complete a password login — Google sends it to the bot IdP and you'll see the message *"This page is used by Meeting BaaS bots during automated SSO sign-in…"*. Escape hatch for an already-scoped account: temporarily move it to an OU without the profile (or remove it from the assigned group), complete the Welcome flow, then move it back.
+</Callout>
+
+### Verifying SSO routing (optional)
+
+To check that Google routes a bot account to Meeting BaaS: open an incognito window, go to `accounts.google.com`, and type the bot account's email. If routing works, you land on a Meeting BaaS page saying **"This page is used by Meeting BaaS bots during automated SSO sign-in… your SSO setup is working."** That error page **is** the success signal — the sign-in itself can only be completed by a bot, never by a human.
 
 <Callout type="tip">
 Create a **Google Group** (for example `bots@bots.acme.com`) and add the bot users as members. Putting this group on a calendar invite lets the assigned bot land in Meet's **verified queue** and bypass the waiting room. You'll reference this group as `email_group` in Step 4.

--- a/content/docs/api-v2/authenticated-bots/meet/setup.mdx
+++ b/content/docs/api-v2/authenticated-bots/meet/setup.mdx
@@ -149,6 +149,10 @@ These `/v2/meet-sso/*` URLs are SAML endpoints that Google calls during sign-in 
 <Step>
 ### Assign the profile to your bot group (or OU) only
 
+<Callout type="warn">
+**Do this assignment last** — only after your bot accounts exist and have completed their first interactive login ([Step 3](#step-3--prepare-the-workspace-users)). Once an account is in the assigned scope, Google routes *every* sign-in — including the first one — to the Meeting BaaS IdP, which only bots can complete; a human can then no longer finish the "Welcome to Workspace" flow. Configure the profile now, prepare the users, then return here to assign.
+</Callout>
+
 Open **Manage SSO profile assignments**. Under **Groups**, pick the group that contains your bot accounts (for example `bots@bots.acme.com`) — or choose the bot **organizational unit**. A new scope starts with **Select SSO profile: None**.
 
 <ImageZoom
@@ -174,7 +178,7 @@ Assign the profile to the bot group/OU **only**. Never assign it to a scope that
 </Callout>
 
 <Callout type="warn">
-**Complete each bot account's first login *before* it enters this SSO scope** (see [Step 3](#step-3--prepare-the-workspace-users)). Once an account is covered by the profile, Google routes *every* sign-in — including the very first one — to the Meeting BaaS IdP, which only bots can complete. A human can then no longer finish the "Welcome to Workspace" flow. If you scoped a whole domain (the recommended dedicated-domain setup), assign the profile **after** preparing the users, or temporarily exclude an account while you complete its first login.
+If you use a dedicated bot-only domain and scope the profile to the whole domain, every account on it — including ones you create later — is born inside SSO scope. For accounts added after this assignment, temporarily exclude them while you complete their first login (see the escape hatch in [Step 3](#step-3--prepare-the-workspace-users)).
 </Callout>
 </Step>
 
@@ -189,12 +193,19 @@ For **each** Google account the bots will sign in as:
 3. Set the account language to **English (United States)** to ensure the sign-in and Meet UIs are in the expected state.
 
 <Callout type="warn">
-**Do the interactive first login while the account is *not yet* covered by the Legacy SSO profile.** An account already in SSO scope cannot complete a password login — Google sends it to the bot IdP and you'll see the message *"This page is used by Meeting BaaS bots during automated SSO sign-in…"*. Escape hatch for an already-scoped account: temporarily move it to an OU without the profile (or remove it from the assigned group), complete the Welcome flow, then move it back.
+**Do the interactive first login while the account is *not yet* covered by the Legacy SSO profile.** An account already in SSO scope cannot complete a password login — Google sends it to the bot IdP and you'll see the message *"This page is used by Meeting BaaS bots during automated SSO sign-in…"*.
+
+Escape hatch for an already-scoped account, depending on how the profile is assigned:
+
+- **Group-assigned:** remove the account from the assigned group. Moving it to another OU is **not** enough — group membership keeps routing it to the IdP.
+- **OU-assigned:** move the account to an OU the profile is not assigned to.
+
+Then confirm no effective SSO assignment remains on the account, wait a few minutes for the change to propagate, complete the Welcome flow with the password, and restore the account to its group/OU.
 </Callout>
 
 ### Verifying SSO routing (optional)
 
-To check that Google routes a bot account to Meeting BaaS: open an incognito window, go to `accounts.google.com`, and type the bot account's email. If routing works, you land on a Meeting BaaS page saying **"This page is used by Meeting BaaS bots during automated SSO sign-in… your SSO setup is working."** That error page **is** the success signal — the sign-in itself can only be completed by a bot, never by a human.
+Once an account has completed its first login **and is (back) in SSO scope**, you can check that Google routes it to Meeting BaaS: open an incognito window, go to `accounts.google.com`, and type the bot account's email. If routing works, you land on a Meeting BaaS page saying **"This page is used by Meeting BaaS bots during automated SSO sign-in… your SSO setup is working."** That error page **is** the success signal — the sign-in itself can only be completed by a bot, never by a human.
 
 <Callout type="tip">
 Create a **Google Group** (for example `bots@bots.acme.com`) and add the bot users as members. Putting this group on a calendar invite lets the assigned bot land in Meet's **verified queue** and bypass the waiting room. You'll reference this group as `email_group` in Step 4.


### PR DESCRIPTION
A bot account that is already covered by the Legacy SSO profile cannot complete its first interactive login — Google routes even the first sign-in to the Meeting BaaS IdP, which only bots can complete. The guide currently orders profile assignment (Step 2) before user preparation (Step 3), so customers following it — especially on the recommended dedicated-domain path, where the whole domain is in scope — hit a deadlock at Step 3.2. This is exactly what happened to Diio (support thread 2026-08-13).

Changes:
- Warn in Step 2 (assignment) and Step 3 (first login) about the ordering constraint, with the temporary-exclusion escape hatch for already-scoped accounts.
- Add an optional "Verifying SSO routing" section documenting the incognito test and its expected outcome: landing on our IdP error page IS the success signal; humans can never complete the sign-in.

Companion PR meeting-baas-v2#415 makes the IdP error page itself say this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)